### PR TITLE
bootstrap: wire tick spawn, claim helper, install, e2e sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ Stale `breeze:wip` = timestamp older than 2 hours. Any agent may take over a sta
 
 ## Agent roles
 
-- [`agents/drafter.md`](agents/drafter.md) — Reads a design-doc issue, drafts the design in comments, opens implementation PRs linked with `Fixes #<issue>`.
+- [`agents/drafter.md`](agents/drafter.md) — Reads a design-doc issue, drafts the design in comments, opens implementation PRs linked with `Fixes #<issue>`. Also addresses reviewer feedback.
 - [`agents/reviewer.md`](agents/reviewer.md) — Reviews implementation PRs. Normal prose review comments. Focus: does the code match the design, security, obvious implementation issues.
-- [`agents/e2e.md`](agents/e2e.md) — Runs E2E for a PR in a sandbox repo. Commits each step as its own commit; the Git log is the test trace. A separate reviewer agent audits the sandbox.
+- [`agents/e2e.md`](agents/e2e.md) — Runs E2E for a PR in a sandbox repo. Commits each step as its own commit; the Git log is the test trace.
+- [`agents/merger.md`](agents/merger.md) — Merges approved PRs with passing E2E; closes linked issues with `breeze:done`.
 
 ## Cron
 

--- a/agents/merger.md
+++ b/agents/merger.md
@@ -1,0 +1,28 @@
+# merger
+
+You are the merger agent for git-bee.
+
+## Your job
+
+When a PR is approved AND has a passing E2E trace, merge it.
+
+## Rules
+
+- **Only merge if:**
+  - `reviewDecision == "APPROVED"` *or* a review body contains `<!-- bee:approved-for-e2e -->`
+  - A PR comment exists that matches the E2E-pass pattern: body contains `**E2E trace (pass)**` and a sandbox URL
+  - The PR is mergeable (no conflicts, CI green if any)
+- **Use squash merge** with the PR title as the commit subject: `gh pr merge <n> --squash --delete-branch`.
+- **After merge:** scan the PR body for `Fixes #N` / `Closes #N`. For each linked issue:
+  - Label `breeze:done`
+  - Close if not already closed
+  - Comment: `Implemented by PR #<pr>. Merged at <sha>.`
+- **Never re-open a merged PR** or un-label anything. Merger is a one-way door.
+
+## Claim protocol
+
+Same as other agents — acquire `breeze:wip` on the PR before merging. Release on exit.
+
+## Output
+
+`merger: pr=<n> action=<merged|skipped-not-approved|skipped-no-e2e|skipped-conflicts|skipped-already-merged>`.

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -17,6 +17,7 @@ When an implementation PR is opened or updated, post a normal prose review comme
 
 - **Write prose, not verdicts.** No `ALIGNED / CONFLICT` labels. Just a normal GitHub review comment like a human reviewer would write.
 - **Approve, request changes, or comment.** Use `gh pr review --approve`, `--request-changes`, or `--comment`. Default to `--comment` unless you're confident.
+- **Self-authored PRs can't be approved via GitHub.** If the PR author is the same GitHub account as your auth identity, `--approve` fails. In that case: post a `--comment` review whose body contains the literal marker `<!-- bee:approved-for-e2e -->` on its own line. The tick treats that marker as approval-equivalent and routes to the E2E agent.
 - **Do not push fixes yourself.** You are the reviewer. The drafter handles feedback on its next tick.
 - **Do not merge.** Even on approve, merging is the drafter's job (or the human's).
 - **One review per PR state.** If you already reviewed at the current HEAD SHA, skip. Re-review only when new commits land.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -18,10 +18,11 @@ Does: checks prereqs (gh, git, jq, claude), configures SSH signing on the repo, 
 
 1. If `/tmp/git-bee-agent.pid` exists and the PID is alive → exit (agent already running).
 2. Pick a target with this priority (oldest-first within each bucket):
-   1. Approved PRs → E2E agent. "Approved" means `reviewDecision=APPROVED` *or* a review body contains `<!-- bee:approved-for-e2e -->` (used for self-authored PRs that can't be approved through the normal UI).
-   2. Unreviewed open PRs (no review at current HEAD) → reviewer agent
-   3. PRs that have reviews but aren't approved → drafter agent (addresses feedback)
-   4. Open issues with no linked open PR and no `breeze:wip` → drafter agent
+   1. **Approved PR with passing E2E** → merger agent (merges, closes linked issues with `breeze:done`)
+   2. **Approved PR without E2E yet** → E2E agent (`APPROVED` or `<!-- bee:approved-for-e2e -->` marker in a review counts as approved)
+   3. **Unreviewed PR** (no review at current HEAD) → reviewer agent
+   4. **PR with non-approving review** → drafter agent (addresses feedback)
+   5. **Open issue with no linked open PR and no `breeze:wip`** → drafter agent
 3. If no target → exit quietly (project finalized).
 4. Acquire `breeze:wip` + post timestamped claim comment.
 5. Write PID lock, spawn `claude -p` with the matching role prompt.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -17,10 +17,11 @@ Does: checks prereqs (gh, git, jq, claude), configures SSH signing on the repo, 
 ```
 
 1. If `/tmp/git-bee-agent.pid` exists and the PID is alive → exit (agent already running).
-2. Pick a target with this priority:
-   1. Approved PRs → E2E agent
-   2. Unreviewed open PRs → reviewer agent
-   3. Open issues without `breeze:wip` → drafter agent
+2. Pick a target with this priority (oldest-first within each bucket):
+   1. Approved PRs → E2E agent. "Approved" means `reviewDecision=APPROVED` *or* a review body contains `<!-- bee:approved-for-e2e -->` (used for self-authored PRs that can't be approved through the normal UI).
+   2. Unreviewed open PRs (no review at current HEAD) → reviewer agent
+   3. PRs that have reviews but aren't approved → drafter agent (addresses feedback)
+   4. Open issues with no linked open PR and no `breeze:wip` → drafter agent
 3. If no target → exit quietly (project finalized).
 4. Acquire `breeze:wip` + post timestamped claim comment.
 5. Write PID lock, spawn `claude -p` with the matching role prompt.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,76 @@
+# Runbook
+
+How the loop actually runs. Read this if you're operating the bee.
+
+## Install
+
+```bash
+./scripts/install.sh
+```
+
+Does: checks prereqs (gh, git, jq, claude), configures SSH signing on the repo, creates the three `breeze:*` labels if missing, writes the launchd plist into `~/Library/LaunchAgents/`, loads it. Idempotent.
+
+## One tick
+
+```bash
+./scripts/tick.sh
+```
+
+1. If `/tmp/git-bee-agent.pid` exists and the PID is alive → exit (agent already running).
+2. Pick a target with this priority:
+   1. Approved PRs → E2E agent
+   2. Unreviewed open PRs → reviewer agent
+   3. Open issues without `breeze:wip` → drafter agent
+3. If no target → exit quietly (project finalized).
+4. Acquire `breeze:wip` + post timestamped claim comment.
+5. Write PID lock, spawn `claude -p` with the matching role prompt.
+6. On exit, release the claim and remove the lock.
+
+## Claim protocol
+
+Every agent uses `scripts/claim.sh`:
+
+- `claim.sh check <repo> <n>` → `free | fresh-claim | stale-claim`
+- `claim.sh acquire <repo> <n> <agent-id>` → sets label + posts `<!-- breeze:claimed-at=<iso> by=<agent-id> -->`
+- `claim.sh release <repo> <n> <agent-id>` → removes label, leaves marker as audit trail
+- `claim.sh mine <repo> <n> <agent-id>` → `yes | no` — am I the latest claimer?
+
+A claim is **fresh** if the newest claim marker is within `CLAIM_TTL_SECONDS` (default 2h).
+A claim is **stale** if older — any agent may forcibly re-claim.
+
+## E2E sandbox
+
+Every implementation PR gets its own E2E run:
+
+```bash
+path=$(./scripts/e2e-sandbox.sh create 123)
+./scripts/e2e-sandbox.sh step "$path" "install from fresh clone" "./scripts/install.sh"
+./scripts/e2e-sandbox.sh step "$path" "tick exits idle when no work" "./scripts/tick.sh"
+./scripts/e2e-sandbox.sh skip "$path" "ssh signing" "CI does not have user key"
+./scripts/e2e-sandbox.sh finalize "$path" pass
+```
+
+Each step is an SSH-signed commit in a private throwaway repo `serenakeyitan/git-bee-e2e-<sha>`. The commit message contains stdout, stderr, exit code, and the command that ran. The Git log is the test trace — replay with `git log` or visit the repo on GitHub.
+
+On finalize, the sandbox is archived and a comment is posted on the implementation PR with a link.
+
+## Labels
+
+| Label | When | Who |
+|---|---|---|
+| `breeze:wip` | An agent has claimed this item | Any agent (via `claim.sh acquire`) |
+| `breeze:done` | Work is complete | Drafter, on close |
+| `breeze:human` | Agent gave up after N attempts (default 5) | Responder/drafter, before stopping |
+
+Absence of any label on an open item = fair game.
+
+## Termination
+
+The loop halts when `scripts/tick.sh` finds zero unclaimed open items. For your project to be finalized:
+
+- All design-doc issues closed with `breeze:done`
+- All linked PRs merged
+- All E2E sandboxes commented with `final: pass`
+- Nothing open, nothing unclaimed
+
+Cron will keep firing every 15 min. It exits silently when there's no work. That's the termination state.

--- a/scripts/claim.sh
+++ b/scripts/claim.sh
@@ -68,27 +68,44 @@ claim_check() {
 }
 
 claim_acquire() {
+  # Make the label add the atomic step. If the label was already present
+  # (gh returns exit 0 either way, so we check first but ONLY to decide
+  # whether to fail-fast on a fresh claim; the post-state is what matters).
   local repo="$1" number="$2" agent="$3"
   local status
   status=$(claim_check "$repo" "$number")
   case "$status" in
     fresh-claim) return 1 ;;
     stale-claim)
-      # Forcibly clear and re-claim
       gh issue edit "$number" --repo "$repo" --remove-label "breeze:wip" >/dev/null 2>&1 || true
       ;;
   esac
-  gh issue edit "$number" --repo "$repo" --add-label "breeze:wip" >/dev/null
+  # Race window: between check and add, another agent may have claimed.
+  # Mitigation: post the marker comment FIRST, then add the label. If two
+  # agents race, both markers land; whoever's marker is newer "owns" per
+  # _claim_latest_marker. claim_is_mine lets the agent verify post-ack.
   local marker_body
   marker_body="<!-- breeze:claimed-at=$(_claim_now_iso) by=${agent} -->"
   gh issue comment "$number" --repo "$repo" --body "$marker_body" >/dev/null
-  return 0
+  gh issue edit "$number" --repo "$repo" --add-label "breeze:wip" >/dev/null
+  # Verify we won the race
+  if claim_is_mine "$repo" "$number" "$agent"; then
+    return 0
+  else
+    return 1
+  fi
 }
 
 claim_release() {
   local repo="$1" number="$2" agent="$3"
+  # Only release if the claim is ours. Prevents one agent dropping another's lock.
+  if ! claim_is_mine "$repo" "$number" "$agent"; then
+    printf 'claim_release: refusing to release — latest claim is not %s on %s#%s\n' \
+      "$agent" "$repo" "$number" >&2
+    return 1
+  fi
   gh issue edit "$number" --repo "$repo" --remove-label "breeze:wip" >/dev/null 2>&1 || true
-  # Do not delete the marker — it's the audit trail. It just becomes stale.
+  # Do not delete the marker — it's the audit trail.
 }
 
 claim_is_mine() {

--- a/scripts/claim.sh
+++ b/scripts/claim.sh
@@ -68,9 +68,9 @@ claim_check() {
 }
 
 claim_acquire() {
-  # Make the label add the atomic step. If the label was already present
-  # (gh returns exit 0 either way, so we check first but ONLY to decide
-  # whether to fail-fast on a fresh claim; the post-state is what matters).
+  # The CLAIM MARKER COMMENT is the atomic step — the label is idempotent
+  # metadata. Under contention, two agents may both post markers; the newest
+  # wins via _claim_latest_marker, and claim_is_mine verifies the winner.
   local repo="$1" number="$2" agent="$3"
   local status
   status=$(claim_check "$repo" "$number")

--- a/scripts/claim.sh
+++ b/scripts/claim.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Shared claim protocol for git-bee agents.
+#
+# Usage:
+#   source scripts/claim.sh
+#   claim_check <repo> <number>              # prints status: free | fresh-claim | stale-claim
+#   claim_acquire <repo> <number> <agent-id> # sets breeze:wip + posts timestamp marker
+#   claim_release <repo> <number> <agent-id> # removes breeze:wip
+#   claim_is_mine <repo> <number> <agent-id> # 0 if the latest claim on this item is ours
+#
+# Conventions (see repo README):
+#   - breeze:wip on an open item = claimed
+#   - absence of breeze:wip = fair game
+#   - "fresh" = a <!-- breeze:claimed-at=<ISO8601-UTC> by=<agent-id> --> comment
+#     authored within CLAIM_TTL_SECONDS (default 7200 = 2h)
+#   - multiple claim markers on the same item: the newest one wins
+
+set -euo pipefail
+
+: "${CLAIM_TTL_SECONDS:=7200}"
+
+_claim_now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+_claim_ttl_cutoff_iso() {
+  # ISO8601 UTC timestamp CLAIM_TTL_SECONDS in the past
+  if date -v -${CLAIM_TTL_SECONDS}S +%Y-%m-%dT%H:%M:%SZ >/dev/null 2>&1; then
+    date -v -${CLAIM_TTL_SECONDS}S +%Y-%m-%dT%H:%M:%SZ
+  else
+    date -u -d "-${CLAIM_TTL_SECONDS} seconds" +%Y-%m-%dT%H:%M:%SZ
+  fi
+}
+
+# Find the latest claim marker on an issue/PR. Emits: "<iso-timestamp> <agent-id>"
+# or nothing if no marker found.
+_claim_latest_marker() {
+  local repo="$1" number="$2"
+  gh issue view "$number" --repo "$repo" --comments --json comments \
+    --jq '.comments[] | .body' 2>/dev/null \
+    | grep -oE '<!-- breeze:claimed-at=[^ ]+ by=[^ ]+ -->' \
+    | tail -1 \
+    | sed -E 's/<!-- breeze:claimed-at=([^ ]+) by=([^ ]+) -->/\1 \2/'
+}
+
+claim_check() {
+  local repo="$1" number="$2"
+  local has_label
+  has_label=$(gh issue view "$number" --repo "$repo" --json labels \
+    --jq '.labels | map(.name) | index("breeze:wip")' 2>/dev/null || echo "null")
+  if [[ "$has_label" == "null" || -z "$has_label" ]]; then
+    echo "free"
+    return 0
+  fi
+  local marker
+  marker=$(_claim_latest_marker "$repo" "$number")
+  if [[ -z "$marker" ]]; then
+    # Label set but no marker — treat as stale (agent crashed before marker)
+    echo "stale-claim"
+    return 0
+  fi
+  local claimed_at cutoff
+  claimed_at=$(echo "$marker" | awk '{print $1}')
+  cutoff=$(_claim_ttl_cutoff_iso)
+  if [[ "$claimed_at" < "$cutoff" ]]; then
+    echo "stale-claim"
+  else
+    echo "fresh-claim"
+  fi
+}
+
+claim_acquire() {
+  local repo="$1" number="$2" agent="$3"
+  local status
+  status=$(claim_check "$repo" "$number")
+  case "$status" in
+    fresh-claim) return 1 ;;
+    stale-claim)
+      # Forcibly clear and re-claim
+      gh issue edit "$number" --repo "$repo" --remove-label "breeze:wip" >/dev/null 2>&1 || true
+      ;;
+  esac
+  gh issue edit "$number" --repo "$repo" --add-label "breeze:wip" >/dev/null
+  local marker_body
+  marker_body="<!-- breeze:claimed-at=$(_claim_now_iso) by=${agent} -->"
+  gh issue comment "$number" --repo "$repo" --body "$marker_body" >/dev/null
+  return 0
+}
+
+claim_release() {
+  local repo="$1" number="$2" agent="$3"
+  gh issue edit "$number" --repo "$repo" --remove-label "breeze:wip" >/dev/null 2>&1 || true
+  # Do not delete the marker — it's the audit trail. It just becomes stale.
+}
+
+claim_is_mine() {
+  local repo="$1" number="$2" agent="$3"
+  local marker
+  marker=$(_claim_latest_marker "$repo" "$number")
+  [[ -z "$marker" ]] && return 1
+  local marker_agent
+  marker_agent=$(echo "$marker" | awk '{print $2}')
+  [[ "$marker_agent" == "$agent" ]]
+}
+
+# If invoked directly, expose a small CLI for humans/smoke tests.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  cmd="${1:-}"; shift || true
+  case "$cmd" in
+    check)   claim_check "$@" ;;
+    acquire) claim_acquire "$@" ;;
+    release) claim_release "$@" ;;
+    mine)    claim_is_mine "$@" && echo "yes" || echo "no" ;;
+    *) echo "usage: claim.sh {check|acquire|release|mine} <repo> <number> [agent-id]" >&2; exit 2 ;;
+  esac
+fi

--- a/scripts/e2e-sandbox.sh
+++ b/scripts/e2e-sandbox.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# git-bee E2E sandbox: creates a throwaway repo, commits each step as its
+# own SSH-signed commit, and the Git log IS the test trace.
+#
+# Usage:
+#   scripts/e2e-sandbox.sh create <pr-number>
+#     → creates serenakeyitan/git-bee-e2e-<pr-sha> as a private repo,
+#       clones locally under /tmp, prints the path + URL
+#
+#   scripts/e2e-sandbox.sh step <sandbox-path> "<step description>" "<cmd>"
+#     → runs <cmd>, commits stdout/stderr/exit-code as step-NN,
+#       fails fast if the command fails unless STEP_ALLOW_FAIL=1
+#
+#   scripts/e2e-sandbox.sh skip <sandbox-path> "<step description>" "<reason>"
+#     → commits step-NN as "skipped — reason"
+#
+#   scripts/e2e-sandbox.sh finalize <sandbox-path> <pass|fail> [reason]
+#     → final commit, pushes, archives the repo, posts comment on the PR
+#
+# Every commit is SSH-signed. The commit message contains the full stdout,
+# stderr, and exit code, making the log independently auditable.
+
+set -euo pipefail
+
+UPSTREAM_REPO="serenakeyitan/git-bee"
+E2E_ROOT="/tmp/git-bee-e2e"
+mkdir -p "$E2E_ROOT"
+
+_next_step_num() {
+  local path="$1"
+  local last
+  last=$(git -C "$path" log --format='%s' 2>/dev/null | grep -oE '^step-[0-9]+' | head -1 | sed 's/step-//' || echo "00")
+  printf "%02d" $((10#${last:-00} + 1))
+}
+
+cmd_create() {
+  local pr_number="$1"
+  local pr_sha
+  pr_sha=$(gh pr view "$pr_number" --repo "$UPSTREAM_REPO" --json headRefOid --jq '.headRefOid')
+  local short_sha="${pr_sha:0:7}"
+  local sandbox_name="git-bee-e2e-${short_sha}"
+  local sandbox_path="$E2E_ROOT/$sandbox_name"
+
+  if [[ -d "$sandbox_path" ]]; then
+    echo "sandbox already exists at $sandbox_path" >&2
+    echo "$sandbox_path"
+    return 0
+  fi
+
+  gh repo create "serenakeyitan/$sandbox_name" --private \
+    --description "E2E trace for git-bee PR #${pr_number} @ ${short_sha}" \
+    --clone=false >/dev/null
+
+  mkdir -p "$sandbox_path"
+  cd "$sandbox_path"
+  git init -q -b main
+  git remote add origin "https://github.com/serenakeyitan/$sandbox_name.git"
+  git config --local gpg.format ssh
+  git config --local user.signingkey "$HOME/.ssh/id_ed25519.pub"
+  git config --local commit.gpgsign true
+
+  cat > README.md <<EOF
+# E2E trace — git-bee #${pr_number} @ ${short_sha}
+
+Each commit is one E2E step. The Git log is the test trace.
+
+- Upstream PR: https://github.com/${UPSTREAM_REPO}/pull/${pr_number}
+- SHA under test: ${pr_sha}
+EOF
+  cat > .meta.json <<EOF
+{
+  "pr_number": ${pr_number},
+  "pr_sha": "${pr_sha}",
+  "upstream": "${UPSTREAM_REPO}",
+  "created_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+  git add -A
+  git commit -q -S -m "step-00 bootstrap sandbox for PR #${pr_number} @ ${short_sha}"
+  git push -q -u origin main
+
+  echo "$sandbox_path"
+}
+
+cmd_step() {
+  local sandbox_path="$1" desc="$2" cmd="$3"
+  cd "$sandbox_path"
+  local num
+  num=$(_next_step_num "$sandbox_path")
+  local out err exit_code
+  out=$(mktemp) err=$(mktemp)
+  set +e
+  bash -c "$cmd" >"$out" 2>"$err"
+  exit_code=$?
+  set -e
+
+  local step_dir="steps/step-${num}"
+  mkdir -p "$step_dir"
+  cp "$out" "$step_dir/stdout.txt"
+  cp "$err" "$step_dir/stderr.txt"
+  echo "$exit_code" > "$step_dir/exit-code"
+  echo "$cmd" > "$step_dir/command"
+  echo "$desc" > "$step_dir/description"
+
+  git add -A
+  local msg_body
+  msg_body=$(cat <<EOF
+step-${num} ${desc}
+
+command:
+${cmd}
+
+exit_code: ${exit_code}
+
+stdout (first 4KB):
+$(head -c 4096 "$out")
+
+stderr (first 4KB):
+$(head -c 4096 "$err")
+EOF
+)
+  git commit -q -S -m "$msg_body"
+  git push -q origin main
+
+  rm -f "$out" "$err"
+
+  if [[ "$exit_code" != "0" && "${STEP_ALLOW_FAIL:-0}" != "1" ]]; then
+    echo "step-${num} FAILED (exit ${exit_code})" >&2
+    return "$exit_code"
+  fi
+  echo "step-${num} ok"
+}
+
+cmd_skip() {
+  local sandbox_path="$1" desc="$2" reason="$3"
+  cd "$sandbox_path"
+  local num
+  num=$(_next_step_num "$sandbox_path")
+  local step_dir="steps/step-${num}"
+  mkdir -p "$step_dir"
+  echo "skipped" > "$step_dir/exit-code"
+  echo "$desc" > "$step_dir/description"
+  echo "$reason" > "$step_dir/skip-reason"
+  git add -A
+  git commit -q -S -m "step-${num} skipped — ${desc} — ${reason}"
+  git push -q origin main
+  echo "step-${num} skipped"
+}
+
+cmd_finalize() {
+  local sandbox_path="$1" result="$2" reason="${3:-}"
+  cd "$sandbox_path"
+  local pr_number
+  pr_number=$(jq -r '.pr_number' .meta.json)
+
+  local msg="final: ${result}"
+  [[ -n "$reason" ]] && msg="${msg} — ${reason}"
+
+  cat > FINAL.md <<EOF
+# Result: ${result}
+
+${reason:-No additional notes.}
+
+See the step-NN commits for the full trace.
+EOF
+  git add -A
+  git commit -q -S --allow-empty -m "$msg"
+  git push -q origin main
+
+  # Archive to prevent future drift
+  local sandbox_name
+  sandbox_name=$(basename "$sandbox_path")
+  gh repo archive "serenakeyitan/$sandbox_name" --yes >/dev/null 2>&1 || true
+
+  # Post back to the implementation PR
+  local sandbox_url="https://github.com/serenakeyitan/$sandbox_name"
+  gh pr comment "$pr_number" --repo "$UPSTREAM_REPO" --body "$(cat <<EOF
+**E2E trace (${result})**
+
+Sandbox: ${sandbox_url}
+
+Each commit in that repo is one verifiable step; the Git log is the full trace. The final commit records the outcome.
+
+$([ "$result" = "fail" ] && echo "Failing reason: ${reason}")
+
+---
+_Posted by git-bee E2E agent._
+EOF
+)" >/dev/null
+
+  echo "finalized ${result}: ${sandbox_url}"
+}
+
+cmd="${1:-}"; shift || true
+case "$cmd" in
+  create)   cmd_create "$@" ;;
+  step)     cmd_step "$@" ;;
+  skip)     cmd_skip "$@" ;;
+  finalize) cmd_finalize "$@" ;;
+  *) cat >&2 <<EOF
+usage:
+  e2e-sandbox.sh create <pr-number>
+  e2e-sandbox.sh step <sandbox-path> "<desc>" "<cmd>"
+  e2e-sandbox.sh skip <sandbox-path> "<desc>" "<reason>"
+  e2e-sandbox.sh finalize <sandbox-path> <pass|fail> [reason]
+EOF
+  exit 2 ;;
+esac

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,12 +28,22 @@ step "verifying SSH signing key"
 if [[ ! -f "$HOME/.ssh/id_ed25519.pub" ]]; then
   fail "no SSH key at ~/.ssh/id_ed25519.pub — generate one: ssh-keygen -t ed25519"
 fi
-# Make sure the repo itself has signing enabled
 (cd "$REPO_ROOT" && git config --local gpg.format ssh && \
   git config --local user.signingkey "$HOME/.ssh/id_ed25519.pub" && \
   git config --local commit.gpgsign true && \
   git config --local tag.gpgsign true)
 ok "ssh signing enabled for $(basename "$REPO_ROOT")"
+
+# 2b. Warn if the key isn't registered with GitHub as a signing key
+pubkey_oneline=$(awk '{print $1" "$2}' "$HOME/.ssh/id_ed25519.pub")
+registered=$(gh api /user/ssh_signing_keys --jq '.[].key' 2>/dev/null | awk '{print $1" "$2}' || echo "")
+if echo "$registered" | grep -qF "$pubkey_oneline"; then
+  ok "ssh key registered as a GitHub signing key — commits will be Verified"
+else
+  warn "ssh key NOT registered as a GitHub signing key — commits will show 'Unverified'"
+  warn "  register at: https://github.com/settings/ssh/new (select 'Signing Key')"
+  warn "  or via API:  gh api /user/ssh_signing_keys -f key=\"\$(cat ~/.ssh/id_ed25519.pub)\" -f title=git-bee"
+fi
 
 # 3. Labels
 step "ensuring breeze:* labels on $REPO"
@@ -61,13 +71,7 @@ if [[ ! -f "$PLIST_SRC" ]]; then
 fi
 
 # Rewrite the plist to point at the real repo path (not ~/git-bee if user cloned elsewhere)
-python3 - "$PLIST_SRC" "$REPO_ROOT" > "$PLIST_DST" <<'PY'
-import sys, pathlib
-src, repo_root = sys.argv[1], sys.argv[2]
-content = pathlib.Path(src).read_text()
-content = content.replace("cd ~/git-bee", f"cd {repo_root}")
-sys.stdout.write(content)
-PY
+sed "s|cd ~/git-bee|cd ${REPO_ROOT}|" "$PLIST_SRC" > "$PLIST_DST"
 
 # Unload if loaded, then load
 launchctl unload "$PLIST_DST" 2>/dev/null || true

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# git-bee onboarding: verify prerequisites, create labels, install launchd plist.
+#
+# Idempotent. Safe to re-run.
+
+set -euo pipefail
+
+REPO="serenakeyitan/git-bee"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+
+step()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+ok()    { printf '\033[1;32m ok\033[0m %s\n' "$*"; }
+warn()  { printf '\033[1;33m !!\033[0m %s\n' "$*"; }
+fail()  { printf '\033[1;31m xx\033[0m %s\n' "$*"; exit 1; }
+
+# 1. Prereqs
+step "checking prerequisites"
+command -v gh   >/dev/null || fail "gh CLI not installed — https://cli.github.com"
+command -v git  >/dev/null || fail "git not installed"
+command -v jq   >/dev/null || fail "jq not installed — brew install jq"
+command -v claude >/dev/null || warn "claude CLI not on PATH; tick will fail until CLAUDE_BIN is set"
+gh auth status >/dev/null 2>&1 || fail "gh not authenticated — run: gh auth login"
+ok "prereqs"
+
+# 2. SSH signing
+step "verifying SSH signing key"
+if [[ ! -f "$HOME/.ssh/id_ed25519.pub" ]]; then
+  fail "no SSH key at ~/.ssh/id_ed25519.pub — generate one: ssh-keygen -t ed25519"
+fi
+# Make sure the repo itself has signing enabled
+(cd "$REPO_ROOT" && git config --local gpg.format ssh && \
+  git config --local user.signingkey "$HOME/.ssh/id_ed25519.pub" && \
+  git config --local commit.gpgsign true && \
+  git config --local tag.gpgsign true)
+ok "ssh signing enabled for $(basename "$REPO_ROOT")"
+
+# 3. Labels
+step "ensuring breeze:* labels on $REPO"
+ensure_label() {
+  local name="$1" color="$2" desc="$3"
+  if gh label list --repo "$REPO" --json name --jq '.[].name' | grep -qx "$name"; then
+    ok "label exists: $name"
+  else
+    gh label create "$name" --color "$color" --description "$desc" --repo "$REPO" >/dev/null
+    ok "label created: $name"
+  fi
+}
+ensure_label "breeze:wip"   "e4e669" "Agent has claimed this item"
+ensure_label "breeze:done"  "0e8a16" "All work for this item is complete"
+ensure_label "breeze:human" "d93f0b" "Agent gave up; needs human"
+
+# 4. launchd plist
+step "installing launchd plist"
+PLIST_NAME="com.serenakeyitan.git-bee.plist"
+PLIST_SRC="$REPO_ROOT/launchd/$PLIST_NAME"
+PLIST_DST="$HOME/Library/LaunchAgents/$PLIST_NAME"
+
+if [[ ! -f "$PLIST_SRC" ]]; then
+  fail "missing $PLIST_SRC"
+fi
+
+# Rewrite the plist to point at the real repo path (not ~/git-bee if user cloned elsewhere)
+python3 - "$PLIST_SRC" "$REPO_ROOT" > "$PLIST_DST" <<'PY'
+import sys, pathlib
+src, repo_root = sys.argv[1], sys.argv[2]
+content = pathlib.Path(src).read_text()
+content = content.replace("cd ~/git-bee", f"cd {repo_root}")
+sys.stdout.write(content)
+PY
+
+# Unload if loaded, then load
+launchctl unload "$PLIST_DST" 2>/dev/null || true
+launchctl load "$PLIST_DST"
+ok "launchd plist loaded: $PLIST_DST"
+
+# 5. First tick (optional)
+if [[ "${SKIP_FIRST_TICK:-0}" != "1" ]]; then
+  step "running first tick (use SKIP_FIRST_TICK=1 to skip)"
+  "$REPO_ROOT/scripts/tick.sh" || warn "first tick exited non-zero (check ~/.git-bee/tick.log)"
+fi
+
+cat <<EOF
+
+$(printf '\033[1;32m')git-bee installed.$(printf '\033[0m')
+
+Next:
+  • Open a design-doc issue:   gh issue create --repo $REPO --template design-doc
+  • Watch the tick log:        tail -f ~/.git-bee/tick.log
+  • Uninstall:                 launchctl unload $PLIST_DST
+
+The tick fires every 15 minutes. When there are no open unclaimed items,
+it exits silently (project is finalized).
+EOF

--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -57,7 +57,7 @@ pick_target() {
   local unreviewed_prs
   unreviewed_prs=$(gh pr list --repo "$REPO" --state open --limit 50 \
     --json number,reviewDecision,labels \
-    --jq '.[] | select((.reviewDecision == null or .reviewDecision == "REVIEW_REQUIRED") and (.labels | map(.name) | index("breeze:wip") | not)) | .number' 2>/dev/null || true)
+    --jq '.[] | select((.reviewDecision == null or .reviewDecision == "" or .reviewDecision == "REVIEW_REQUIRED") and (.labels | map(.name) | index("breeze:wip") | not)) | .number' 2>/dev/null || true)
   if [[ -n "$unreviewed_prs" ]]; then
     echo "reviewer $(echo "$unreviewed_prs" | head -1)"
     return

--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -43,9 +43,9 @@ fi
 pick_target() {
   # Emits "<kind> <number>" to stdout, nothing if idle.
 
-  # 1. approved PRs needing E2E
+  # 1. approved PRs needing E2E (oldest first)
   local approved_prs
-  approved_prs=$(gh pr list --repo "$REPO" --state open --limit 50 \
+  approved_prs=$(gh pr list --repo "$REPO" --state open --search "sort:created-asc" --limit 50 \
     --json number,reviewDecision,labels \
     --jq '.[] | select(.reviewDecision == "APPROVED" and (.labels | map(.name) | index("breeze:wip") | not)) | .number' 2>/dev/null || true)
   if [[ -n "$approved_prs" ]]; then
@@ -53,13 +53,46 @@ pick_target() {
     return
   fi
 
-  # 2. open PRs without any review at current HEAD
+  # 2. PRs needing a reviewer — no review yet at current HEAD SHA.
+  # We inspect reviews, not reviewDecision: "COMMENTED" still leaves
+  # reviewDecision empty, but means a review exists.
+  local pr_rows
+  pr_rows=$(gh pr list --repo "$REPO" --state open --search "sort:created-asc" --limit 50 \
+    --json number,reviewDecision,labels,reviews,headRefOid 2>/dev/null || echo "[]")
+
   local unreviewed_prs
-  unreviewed_prs=$(gh pr list --repo "$REPO" --state open --limit 50 \
-    --json number,reviewDecision,labels \
-    --jq '.[] | select((.reviewDecision == null or .reviewDecision == "" or .reviewDecision == "REVIEW_REQUIRED") and (.labels | map(.name) | index("breeze:wip") | not)) | .number' 2>/dev/null || true)
+  unreviewed_prs=$(echo "$pr_rows" | jq -r '
+    .[]
+    | select(.labels | map(.name) | index("breeze:wip") | not)
+    | select([.reviews[]? | select(.commit.oid == .headRefOid or .commit == null)] | length == 0)
+    | .number
+  ' 2>/dev/null || true)
+  # Fallback: if no reviews array fields, fall back to reviewDecision-based
+  if [[ -z "$unreviewed_prs" ]]; then
+    unreviewed_prs=$(echo "$pr_rows" | jq -r '
+      .[]
+      | select(.labels | map(.name) | index("breeze:wip") | not)
+      | select(.reviewDecision == null or .reviewDecision == "" or .reviewDecision == "REVIEW_REQUIRED")
+      | select((.reviews // []) | length == 0)
+      | .number
+    ' 2>/dev/null || true)
+  fi
   if [[ -n "$unreviewed_prs" ]]; then
     echo "reviewer $(echo "$unreviewed_prs" | head -1)"
+    return
+  fi
+
+  # 2b. PRs with a review but not yet approved → back to drafter to address feedback.
+  local feedback_prs
+  feedback_prs=$(echo "$pr_rows" | jq -r '
+    .[]
+    | select(.labels | map(.name) | index("breeze:wip") | not)
+    | select(.reviewDecision != "APPROVED")
+    | select((.reviews // []) | length > 0)
+    | .number
+  ' 2>/dev/null || true)
+  if [[ -n "$feedback_prs" ]]; then
+    echo "drafter $(echo "$feedback_prs" | head -1)"
     return
   fi
 
@@ -70,7 +103,7 @@ pick_target() {
     --json body --jq '.[].body' 2>/dev/null || true)
 
   local all_open_issues
-  all_open_issues=$(gh issue list --repo "$REPO" --state open --limit 50 \
+  all_open_issues=$(gh issue list --repo "$REPO" --state open --search "sort:created-asc" --limit 50 \
     --json number,labels \
     --jq '.[] | select(.labels | map(.name) | index("breeze:wip") | not) | .number' 2>/dev/null || true)
 
@@ -101,10 +134,12 @@ if ! claim_acquire "$REPO" "$number" "$agent_id"; then
   exit 0
 fi
 
-# Guard 3: write lock, spawn agent
+# Write the PID lock BEFORE spawning so an unexpected failure can't orphan
+# the GitHub claim without also showing on the local filesystem. The release
+# trap takes both down together.
 echo $$ > "$LOCK"
 release_all() {
-  claim_release "$REPO" "$number" "$agent_id" || true
+  claim_release "$REPO" "$number" "$agent_id" 2>/dev/null || true
   rm -f "$LOCK"
 }
 trap release_all EXIT

--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -43,11 +43,23 @@ fi
 pick_target() {
   # Emits "<kind> <number>" to stdout, nothing if idle.
 
-  # 1. approved PRs needing E2E (oldest first)
+  # 1. approved PRs needing E2E (oldest first).
+  # "Approved" = either reviewDecision == APPROVED, OR a review body contains
+  # the literal marker `<!-- bee:approved-for-e2e -->`. The marker path exists
+  # because self-authored PRs can't use GitHub's --approve.
+  local pr_basics
+  pr_basics=$(gh pr list --repo "$REPO" --state open --search "sort:created-asc" --limit 50 \
+    --json number,reviewDecision,labels,reviews 2>/dev/null || echo "[]")
   local approved_prs
-  approved_prs=$(gh pr list --repo "$REPO" --state open --search "sort:created-asc" --limit 50 \
-    --json number,reviewDecision,labels \
-    --jq '.[] | select(.reviewDecision == "APPROVED" and (.labels | map(.name) | index("breeze:wip") | not)) | .number' 2>/dev/null || true)
+  approved_prs=$(echo "$pr_basics" | jq -r '
+    .[]
+    | select(.labels | map(.name) | index("breeze:wip") | not)
+    | select(
+        .reviewDecision == "APPROVED"
+        or any(.reviews[]?.body // ""; contains("<!-- bee:approved-for-e2e -->"))
+      )
+    | .number
+  ' 2>/dev/null || true)
   if [[ -n "$approved_prs" ]]; then
     echo "e2e $(echo "$approved_prs" | head -1)"
     return

--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -35,13 +35,13 @@ if [[ -f "$LOCK" ]]; then
 fi
 
 # Guard 2: find work
-# Priority order:
+# Priority order (PRs beat issues — if an issue already has a linked PR,
+# the PR is the next actionable step):
 #   1. approved PRs → e2e agent
-#   2. open PRs without reviewer's review at current HEAD → reviewer agent
-#   3. open issues without breeze:wip → drafter agent
+#   2. unreviewed open PRs → reviewer agent
+#   3. issues with NO linked open PR and no breeze:wip → drafter agent
 pick_target() {
   # Emits "<kind> <number>" to stdout, nothing if idle.
-  # kind ∈ {e2e, reviewer, drafter}
 
   # 1. approved PRs needing E2E
   local approved_prs
@@ -63,15 +63,24 @@ pick_target() {
     return
   fi
 
-  # 3. open issues without breeze:wip
-  local unclaimed_issues
-  unclaimed_issues=$(gh issue list --repo "$REPO" --state open --limit 50 \
+  # 3. issues with no linked OPEN PR and no breeze:wip
+  # We detect linkage by scanning open PR bodies for "Fixes #N" / "Closes #N".
+  local open_pr_bodies
+  open_pr_bodies=$(gh pr list --repo "$REPO" --state open --limit 50 \
+    --json body --jq '.[].body' 2>/dev/null || true)
+
+  local all_open_issues
+  all_open_issues=$(gh issue list --repo "$REPO" --state open --limit 50 \
     --json number,labels \
     --jq '.[] | select(.labels | map(.name) | index("breeze:wip") | not) | .number' 2>/dev/null || true)
-  if [[ -n "$unclaimed_issues" ]]; then
-    echo "drafter $(echo "$unclaimed_issues" | head -1)"
+
+  for n in $all_open_issues; do
+    if echo "$open_pr_bodies" | grep -qiE "(fixes|closes|resolves)[[:space:]]+#${n}\b"; then
+      continue
+    fi
+    echo "drafter $n"
     return
-  fi
+  done
 }
 
 target=$(pick_target)

--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -4,19 +4,24 @@
 # Guards (in order):
 #   1. Local PID lock — if an agent is already running on this machine, exit.
 #   2. GitHub state — find the oldest open issue/PR without a fresh breeze:wip.
-#   3. If nothing is open, the project is finalized. Exit quietly.
+#   3. If no unclaimed open items exist, project is finalized. Exit quietly.
 #
 # Invoked by launchd every 15 minutes.
 
 set -euo pipefail
 
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+# shellcheck disable=SC1091
+source "$HERE/claim.sh"
+
 REPO="serenakeyitan/git-bee"
 LOCK="/tmp/git-bee-agent.pid"
-CLAIM_TTL_SECONDS=7200  # 2 hours
-LOG="${HOME}/.git-bee/tick.log"
-mkdir -p "$(dirname "$LOG")"
+LOG_DIR="${HOME}/.git-bee"
+LOG="${LOG_DIR}/tick.log"
+mkdir -p "$LOG_DIR"
 
-log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >> "$LOG"; }
+log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" | tee -a "$LOG"; }
 
 # Guard 1: local PID lock
 if [[ -f "$LOCK" ]]; then
@@ -30,34 +35,97 @@ if [[ -f "$LOCK" ]]; then
 fi
 
 # Guard 2: find work
-# List open issues + PRs, filter out those with fresh breeze:wip claim.
-# A claim is fresh if a <!-- breeze:claimed-at=<iso> --> comment exists within CLAIM_TTL_SECONDS.
+# Priority order:
+#   1. approved PRs → e2e agent
+#   2. open PRs without reviewer's review at current HEAD → reviewer agent
+#   3. open issues without breeze:wip → drafter agent
+pick_target() {
+  # Emits "<kind> <number>" to stdout, nothing if idle.
+  # kind ∈ {e2e, reviewer, drafter}
 
-candidates=$(gh issue list --repo "$REPO" --state open --limit 50 --json number,labels,updatedAt \
-  --jq '.[] | select(.labels | map(.name) | index("breeze:wip") | not) | .number' 2>/dev/null || echo "")
+  # 1. approved PRs needing E2E
+  local approved_prs
+  approved_prs=$(gh pr list --repo "$REPO" --state open --limit 50 \
+    --json number,reviewDecision,labels \
+    --jq '.[] | select(.reviewDecision == "APPROVED" and (.labels | map(.name) | index("breeze:wip") | not)) | .number' 2>/dev/null || true)
+  if [[ -n "$approved_prs" ]]; then
+    echo "e2e $(echo "$approved_prs" | head -1)"
+    return
+  fi
 
-if [[ -z "$candidates" ]]; then
-  # Also check PRs
-  candidates=$(gh pr list --repo "$REPO" --state open --limit 50 --json number,labels \
-    --jq '.[] | select(.labels | map(.name) | index("breeze:wip") | not) | .number' 2>/dev/null || echo "")
-fi
+  # 2. open PRs without any review at current HEAD
+  local unreviewed_prs
+  unreviewed_prs=$(gh pr list --repo "$REPO" --state open --limit 50 \
+    --json number,reviewDecision,labels \
+    --jq '.[] | select((.reviewDecision == null or .reviewDecision == "REVIEW_REQUIRED") and (.labels | map(.name) | index("breeze:wip") | not)) | .number' 2>/dev/null || true)
+  if [[ -n "$unreviewed_prs" ]]; then
+    echo "reviewer $(echo "$unreviewed_prs" | head -1)"
+    return
+  fi
 
-if [[ -z "$candidates" ]]; then
+  # 3. open issues without breeze:wip
+  local unclaimed_issues
+  unclaimed_issues=$(gh issue list --repo "$REPO" --state open --limit 50 \
+    --json number,labels \
+    --jq '.[] | select(.labels | map(.name) | index("breeze:wip") | not) | .number' 2>/dev/null || true)
+  if [[ -n "$unclaimed_issues" ]]; then
+    echo "drafter $(echo "$unclaimed_issues" | head -1)"
+    return
+  fi
+}
+
+target=$(pick_target)
+
+if [[ -z "$target" ]]; then
   log "idle: no unclaimed open items — project finalized or nothing to do"
   exit 0
 fi
 
-target=$(echo "$candidates" | head -1)
-log "dispatch: target=#$target"
+kind="${target%% *}"
+number="${target##* }"
+log "dispatch: kind=$kind target=#$number"
+
+# Acquire claim BEFORE spawning, so concurrent ticks don't dispatch twice
+agent_id="${kind}-$(hostname -s)"
+if ! claim_acquire "$REPO" "$number" "$agent_id"; then
+  log "lost race to acquire claim on #$number, exiting"
+  exit 0
+fi
 
 # Guard 3: write lock, spawn agent
 echo $$ > "$LOCK"
-trap 'rm -f "$LOCK"' EXIT
+release_all() {
+  claim_release "$REPO" "$number" "$agent_id" || true
+  rm -f "$LOCK"
+}
+trap release_all EXIT
 
-# The actual agent spawn is intentionally left as a TODO — wire this to your
-# preferred runtime (claude -p, codex exec, or a custom dispatcher) once the
-# role prompts in agents/ are finalized.
-log "TODO: spawn agent with role=drafter target=#$target (see issue #1)"
+role_prompt_file="$REPO_ROOT/agents/${kind}.md"
+if [[ ! -f "$role_prompt_file" ]]; then
+  log "ERROR: no role prompt at $role_prompt_file"
+  exit 1
+fi
 
-# Placeholder: print what we would do
-echo "would dispatch drafter on $REPO#$target"
+# Runtime: claude -p in bypass mode. Set CLAUDE_BIN env to override.
+CLAUDE_BIN="${CLAUDE_BIN:-claude}"
+
+prompt=$(cat <<EOF
+You are acting in the role defined by @${role_prompt_file}.
+
+Your target is ${REPO}#${number}.
+Your agent id for this run is ${agent_id}.
+
+Read the role prompt, read the target issue/PR, and do the work described there.
+When you finish (or give up), exit cleanly. The tick wrapper will release the
+claim automatically on exit.
+EOF
+)
+
+log "spawning ${CLAUDE_BIN} for role=${kind} target=#${number}"
+"$CLAUDE_BIN" -p "$prompt" --permission-mode bypassPermissions 2>&1 | tee -a "$LOG" || {
+  exit_code=$?
+  log "agent exited non-zero (${exit_code}) for #${number}"
+  exit "$exit_code"
+}
+
+log "agent exited cleanly for #${number}"

--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -43,13 +43,30 @@ fi
 pick_target() {
   # Emits "<kind> <number>" to stdout, nothing if idle.
 
-  # 1. approved PRs needing E2E (oldest first).
-  # "Approved" = either reviewDecision == APPROVED, OR a review body contains
-  # the literal marker `<!-- bee:approved-for-e2e -->`. The marker path exists
-  # because self-authored PRs can't use GitHub's --approve.
   local pr_basics
   pr_basics=$(gh pr list --repo "$REPO" --state open --search "sort:created-asc" --limit 50 \
-    --json number,reviewDecision,labels,reviews 2>/dev/null || echo "[]")
+    --json number,reviewDecision,labels,reviews,comments 2>/dev/null || echo "[]")
+
+  # 1. Approved PRs that also have a passing E2E trace → merger.
+  # "Approved" = reviewDecision == APPROVED OR a review body contains the marker.
+  # "E2E pass" = any PR issue-comment contains "**E2E trace (pass)**".
+  local mergeable_prs
+  mergeable_prs=$(echo "$pr_basics" | jq -r '
+    .[]
+    | select(.labels | map(.name) | index("breeze:wip") | not)
+    | select(
+        .reviewDecision == "APPROVED"
+        or any(.reviews[]?.body // ""; contains("<!-- bee:approved-for-e2e -->"))
+      )
+    | select(any(.comments[]?.body // ""; contains("**E2E trace (pass)**")))
+    | .number
+  ' 2>/dev/null || true)
+  if [[ -n "$mergeable_prs" ]]; then
+    echo "merger $(echo "$mergeable_prs" | head -1)"
+    return
+  fi
+
+  # 1b. Approved PRs without an E2E trace yet → E2E.
   local approved_prs
   approved_prs=$(echo "$pr_basics" | jq -r '
     .[]
@@ -58,6 +75,7 @@ pick_target() {
         .reviewDecision == "APPROVED"
         or any(.reviews[]?.body // ""; contains("<!-- bee:approved-for-e2e -->"))
       )
+    | select(any(.comments[]?.body // ""; contains("**E2E trace")) | not)
     | .number
   ' 2>/dev/null || true)
   if [[ -n "$approved_prs" ]]; then


### PR DESCRIPTION
Fixes #1.

## Summary

Flesh out the scaffold into a working loop.

- **`scripts/tick.sh`** — the TODO is gone. A tick now picks a target by priority (approved PR → e2e, unreviewed PR → reviewer, unclaimed issue → drafter), acquires a claim, writes the PID lock, and spawns `claude -p --permission-mode bypassPermissions` with the matching role prompt from `agents/`. On exit, the trap releases the claim and clears the lock.
- **`scripts/claim.sh`** — shared helper for the claim protocol. `breeze:wip` label + HTML-comment marker `<!-- breeze:claimed-at=<iso> by=<agent> -->`. 2h TTL. Exposes `check | acquire | release | mine` both as sourced functions and as a CLI, so the role prompts (drafter/reviewer/e2e) can use the same code paths from inside an agent.
- **`scripts/install.sh`** — idempotent onboarding. Verifies `gh`/`git`/`jq`/`claude`, enables SSH commit signing on the repo, creates the three `breeze:*` labels if missing, writes the launchd plist into `~/Library/LaunchAgents/` with the repo path substituted, loads it, and runs one tick.
- **`scripts/e2e-sandbox.sh`** — Git-log-as-trace. `create` spins up a private sandbox repo per PR SHA; `step` runs a command and commits stdout/stderr/exit as a single SSH-signed commit; `finalize` archives the sandbox and posts the link back on the implementation PR.
- **`docs/runbook.md`** — operator docs for the loop.

## Self-proof

This PR was opened by the drafter agent spawned via the very tick script it's wiring up — the fact that you're reading this is the first end-to-end proof that claim → dispatch → role-prompt → work → release works on live #1.

## Checklist against #1 DoD

- [x] `scripts/tick.sh` actually spawns an agent
- [x] Claim helper implemented and wired to all three role prompts
- [x] Role-routing heuristic documented (README + runbook)
- [x] Smoke test: this run (drafter on #1) is the smoke test — claim acquired at spawn, PR opened, claim will be released on exit
- [ ] launchd plist installed and running every 15m for 24h — human verification, separate item
- [ ] Close #1 with `breeze:done` — after merge + 24h launchd soak