### PR TITLE
bee: add 'bee status' CLI for at-a-glance tick state

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -10,6 +10,26 @@ How the loop actually runs. Read this if you're operating the bee.
 
 Does: checks prereqs (gh, git, jq, claude), configures SSH signing on the repo, creates the three `breeze:*` labels if missing, writes the launchd plist into `~/Library/LaunchAgents/`, loads it. Idempotent.
 
+## Status at a glance
+
+```bash
+bee status              # three-section block: agent, launchd, github + last tick log line
+bee status --json       # same data as JSON, for scripting
+bee help                # usage
+```
+
+`bee` is a read-only CLI. It never mutates GitHub or local state. Installed on PATH by `scripts/install.sh` (first writable of `~/.local/bin`, `~/bin`, `/usr/local/bin`, `/opt/homebrew/bin`).
+
+Exit codes:
+
+| Code | Meaning |
+|---|---|
+| `0` | agent idle or running cleanly |
+| `1` | project has `breeze:human` items — someone needs to look |
+| `2` | usage error |
+
+Overrides via env: `GIT_BEE_REPO`, `GIT_BEE_LOCK`, `GIT_BEE_LOG_DIR`.
+
 ## One tick
 
 ```bash

--- a/scripts/bee
+++ b/scripts/bee
@@ -104,9 +104,9 @@ gather_agent() {
   # Best-effort: read the most recent "dispatch:" line from the tick log.
   if [[ -r "$LOG" ]]; then
     local dispatch_line
-    dispatch_line=$(grep -E 'dispatch: kind=[a-z]+ target=#[0-9]+' "$LOG" 2>/dev/null | tail -1 || true)
+    dispatch_line=$(grep -E 'dispatch: kind=[a-z0-9]+ target=#[0-9]+' "$LOG" 2>/dev/null | tail -1 || true)
     if [[ -n "$dispatch_line" ]]; then
-      AGENT_ROLE=$(echo "$dispatch_line" | sed -nE 's/.*kind=([a-z]+).*/\1/p')
+      AGENT_ROLE=$(echo "$dispatch_line" | sed -nE 's/.*kind=([a-z0-9]+).*/\1/p')
       AGENT_TARGET=$(echo "$dispatch_line" | sed -nE 's/.*target=(#[0-9]+).*/\1/p')
     fi
   fi

--- a/scripts/bee
+++ b/scripts/bee
@@ -6,7 +6,23 @@
 
 set -euo pipefail
 
-HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve the real path of this script, following symlinks. macOS lacks
+# `readlink -f` by default, so walk the links manually. Without this, invoking
+# bee through the symlink planted by install.sh would leave HERE pointing at
+# the link's directory and the subsequent `source` would fail.
+_bee_realpath() {
+  local target="$1" dir base
+  while [[ -L "$target" ]]; do
+    dir="$(cd "$(dirname "$target")" && pwd)"
+    target="$(readlink "$target")"
+    [[ "$target" != /* ]] && target="$dir/$target"
+  done
+  dir="$(cd "$(dirname "$target")" && pwd)"
+  base="$(basename "$target")"
+  printf '%s/%s\n' "$dir" "$base"
+}
+
+HERE="$(dirname "$(_bee_realpath "${BASH_SOURCE[0]}")")"
 # shellcheck disable=SC1091
 source "$HERE/claim.sh"
 
@@ -42,6 +58,7 @@ EOF
 
 _iso_to_epoch() {
   # GNU `date -d` and BSD `date -j -f` differ. Try BSD first, then GNU.
+  # On failure emits "0"; callers MUST treat 0 as "unknown", not 1970-01-01.
   local iso="$1"
   if date -j -u -f '%Y-%m-%dT%H:%M:%SZ' "$iso" +%s 2>/dev/null; then
     return
@@ -126,7 +143,9 @@ gather_launchd() {
   fi
   LAUNCHD_STATE="loaded"
 
-  # The plist uses StartInterval (every N seconds). Read it directly.
+  # The plist uses StartInterval (every N seconds). If the plist is ever
+  # switched to StartCalendarInterval we'd silently drop the next-tick
+  # estimate — fine, status still reports `loaded`.
   local plist="$HOME/Library/LaunchAgents/$PLIST_NAME"
   if [[ ! -r "$plist" ]]; then
     return
@@ -192,6 +211,9 @@ gather_github() {
   GH_HUMAN_ITEMS="$human_items"
 
   # Stale claims: walk every open item with breeze:wip and ask claim.sh.
+  # Each claim_check costs 2 `gh issue view` calls, so this loop is O(2N+2)
+  # API calls for N claimed items. Fine at current scale; if `bee status`
+  # ever gets called in a tight loop we should batch via a single GraphQL.
   local wip_issue_numbers wip_pr_numbers
   wip_issue_numbers=$(echo "$issues" | jq -r '.[] | select(.labels | map(.name) | index("breeze:wip")) | .number' 2>/dev/null || true)
   wip_pr_numbers=$(echo "$prs" | jq -r '.[] | select(.labels | map(.name) | index("breeze:wip")) | .number' 2>/dev/null || true)
@@ -258,15 +280,13 @@ render_text() {
   if [[ "$GH_FINALIZED" == "true" ]]; then
     gh_line="all clear — project finalized"
   else
-    local issue_part="${GH_ISSUES_OPEN} issue"; (( GH_ISSUES_OPEN == 1 )) || issue_part="${GH_ISSUES_OPEN} issues"
-    issue_part+=" open"
+    local issue_part pr_part stale_part
+    if (( GH_ISSUES_OPEN == 1 )); then issue_part="1 issue open"; else issue_part="${GH_ISSUES_OPEN} issues open"; fi
     if [[ -n "$GH_ISSUE_NUMBERS" ]]; then
       issue_part+=" (${GH_ISSUE_NUMBERS// /, })"
     fi
-    local pr_part="${GH_PRS_OPEN} PR"; (( GH_PRS_OPEN == 1 )) || pr_part="${GH_PRS_OPEN} PRs"
-    pr_part+=" open"
-    local stale_part="${GH_STALE_CLAIMS} stale claim"
-    (( GH_STALE_CLAIMS == 1 )) || stale_part="${GH_STALE_CLAIMS} stale claims"
+    if (( GH_PRS_OPEN == 1 )); then pr_part="1 PR open"; else pr_part="${GH_PRS_OPEN} PRs open"; fi
+    if (( GH_STALE_CLAIMS == 1 )); then stale_part="1 stale claim"; else stale_part="${GH_STALE_CLAIMS} stale claims"; fi
     gh_line="${issue_part}, ${pr_part}, ${stale_part}"
     if (( GH_HUMAN_ITEMS > 0 )); then
       gh_line+=", ${GH_HUMAN_ITEMS} breeze:human"
@@ -297,7 +317,7 @@ render_json() {
     --argjson prs_open "$GH_PRS_OPEN" \
     --argjson stale_claims "$GH_STALE_CLAIMS" \
     --argjson human_items "$GH_HUMAN_ITEMS" \
-    --argjson finalized "$([[ "$GH_FINALIZED" == "true" ]] && echo true || echo false)" \
+    --argjson finalized "$GH_FINALIZED" \
     --arg tick_log_path "$TICK_LOG_PATH" \
     --arg tick_log_last "$TICK_LOG_LAST" \
     '{

--- a/scripts/bee
+++ b/scripts/bee
@@ -1,0 +1,365 @@
+#!/usr/bin/env bash
+# bee — git-bee status CLI.
+#
+# Read-only introspection of the local tick state and the project's GitHub
+# state. Never mutates. See `bee help` for usage.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$HERE/claim.sh"
+
+REPO="${GIT_BEE_REPO:-serenakeyitan/git-bee}"
+LOCK="${GIT_BEE_LOCK:-/tmp/git-bee-agent.pid}"
+LOG_DIR="${GIT_BEE_LOG_DIR:-${HOME}/.git-bee}"
+LOG="${LOG_DIR}/tick.log"
+PLIST_NAME="com.serenakeyitan.git-bee.plist"
+
+usage() {
+  cat <<EOF
+bee — git-bee status at a glance
+
+Usage:
+  bee                    Show help (this text)
+  bee help               Show help (this text)
+  bee status             Print a terse three-section status block
+  bee status --json      Same data, JSON-encoded
+
+Exit codes:
+  0  agent idle or running cleanly
+  1  project has breeze:human items that need attention
+  2  usage error
+
+Environment:
+  GIT_BEE_REPO       override the target repo (default: serenakeyitan/git-bee)
+  GIT_BEE_LOCK       override PID lock path  (default: /tmp/git-bee-agent.pid)
+  GIT_BEE_LOG_DIR    override log directory  (default: ~/.git-bee)
+EOF
+}
+
+# ---- helpers ---------------------------------------------------------------
+
+_iso_to_epoch() {
+  # GNU `date -d` and BSD `date -j -f` differ. Try BSD first, then GNU.
+  local iso="$1"
+  if date -j -u -f '%Y-%m-%dT%H:%M:%SZ' "$iso" +%s 2>/dev/null; then
+    return
+  fi
+  date -u -d "$iso" +%s 2>/dev/null || echo 0
+}
+
+_fmt_duration() {
+  # Seconds → HH:MM:SS
+  local s="$1"
+  if ! [[ "$s" =~ ^-?[0-9]+$ ]]; then echo "?"; return; fi
+  if (( s < 0 )); then s=0; fi
+  printf '%02d:%02d:%02d' $((s/3600)) $(((s%3600)/60)) $((s%60))
+}
+
+# ---- gather agent state ----------------------------------------------------
+# Emits four globals:
+#   AGENT_STATE       = idle | running
+#   AGENT_PID         = <pid> when running, else empty
+#   AGENT_ROLE        = drafter | reviewer | e2e | merger | "" if unknown
+#   AGENT_TARGET      = "#N" or ""
+#   AGENT_CLAIMED_AGO = seconds since claim, or -1 if unknown
+
+gather_agent() {
+  AGENT_STATE=idle
+  AGENT_PID=""
+  AGENT_ROLE=""
+  AGENT_TARGET=""
+  AGENT_CLAIMED_AGO=-1
+
+  if [[ ! -f "$LOCK" ]]; then
+    return
+  fi
+  local pid
+  pid=$(cat "$LOCK" 2>/dev/null || echo "")
+  if [[ -z "$pid" ]] || ! kill -0 "$pid" 2>/dev/null; then
+    # Stale lock — tick treats it as idle and will clean up next pass.
+    return
+  fi
+  AGENT_STATE=running
+  AGENT_PID="$pid"
+
+  # Best-effort: read the most recent "dispatch:" line from the tick log.
+  if [[ -r "$LOG" ]]; then
+    local dispatch_line
+    dispatch_line=$(grep -E 'dispatch: kind=[a-z]+ target=#[0-9]+' "$LOG" 2>/dev/null | tail -1 || true)
+    if [[ -n "$dispatch_line" ]]; then
+      AGENT_ROLE=$(echo "$dispatch_line" | sed -nE 's/.*kind=([a-z]+).*/\1/p')
+      AGENT_TARGET=$(echo "$dispatch_line" | sed -nE 's/.*target=(#[0-9]+).*/\1/p')
+    fi
+  fi
+
+  # Best-effort: claim age from the latest marker on AGENT_TARGET.
+  if [[ -n "$AGENT_TARGET" ]]; then
+    local n="${AGENT_TARGET#\#}"
+    local marker claimed_at
+    marker=$(_claim_latest_marker "$REPO" "$n" 2>/dev/null || true)
+    if [[ -n "$marker" ]]; then
+      claimed_at=$(echo "$marker" | awk '{print $1}')
+      local then_s now_s
+      then_s=$(_iso_to_epoch "$claimed_at")
+      now_s=$(date -u +%s)
+      if [[ "$then_s" != 0 ]]; then
+        AGENT_CLAIMED_AGO=$((now_s - then_s))
+      fi
+    fi
+  fi
+}
+
+# ---- gather launchd state --------------------------------------------------
+# Emits:
+#   LAUNCHD_STATE          = loaded | not-installed
+#   LAUNCHD_NEXT_TICK_SECS = seconds until next fire, or -1 if unknown
+
+gather_launchd() {
+  LAUNCHD_STATE="not-installed"
+  LAUNCHD_NEXT_TICK_SECS=-1
+
+  local label="${PLIST_NAME%.plist}"
+  if ! launchctl list 2>/dev/null | awk '{print $3}' | grep -qx "$label"; then
+    return
+  fi
+  LAUNCHD_STATE="loaded"
+
+  # The plist uses StartInterval (every N seconds). Read it directly.
+  local plist="$HOME/Library/LaunchAgents/$PLIST_NAME"
+  if [[ ! -r "$plist" ]]; then
+    return
+  fi
+  local interval
+  interval=$(/usr/libexec/PlistBuddy -c 'Print :StartInterval' "$plist" 2>/dev/null || echo "")
+  if ! [[ "$interval" =~ ^[0-9]+$ ]] || (( interval <= 0 )); then
+    return
+  fi
+
+  # Approximate "next tick" from the last tick log entry's timestamp.
+  if [[ ! -r "$LOG" ]]; then
+    return
+  fi
+  local last_iso last_s now_s next_s
+  last_iso=$(grep -oE '^[0-9T:Z\-]+' "$LOG" 2>/dev/null | tail -1 || true)
+  if [[ -z "$last_iso" ]]; then
+    return
+  fi
+  last_s=$(_iso_to_epoch "$last_iso")
+  now_s=$(date -u +%s)
+  if [[ "$last_s" == 0 ]]; then
+    return
+  fi
+  next_s=$((last_s + interval - now_s))
+  if (( next_s < 0 )); then next_s=0; fi
+  LAUNCHD_NEXT_TICK_SECS="$next_s"
+}
+
+# ---- gather github state ---------------------------------------------------
+# Emits:
+#   GH_ISSUES_OPEN   = count
+#   GH_ISSUE_NUMBERS = "#N #M" of open issues (space-joined)
+#   GH_PRS_OPEN      = count
+#   GH_STALE_CLAIMS  = count of open items whose claim is stale (breeze:wip with marker older than TTL, or breeze:wip with no marker)
+#   GH_HUMAN_ITEMS   = count of open items with breeze:human
+#   GH_FINALIZED     = "true" | "false"
+
+gather_github() {
+  GH_ISSUES_OPEN=0
+  GH_ISSUE_NUMBERS=""
+  GH_PRS_OPEN=0
+  GH_STALE_CLAIMS=0
+  GH_HUMAN_ITEMS=0
+  GH_FINALIZED=false
+
+  local issues prs
+  issues=$(gh issue list --repo "$REPO" --state open --limit 100 \
+    --json number,labels 2>/dev/null || echo "[]")
+  prs=$(gh pr list --repo "$REPO" --state open --limit 100 \
+    --json number,labels 2>/dev/null || echo "[]")
+
+  GH_ISSUES_OPEN=$(echo "$issues" | jq 'length' 2>/dev/null || echo 0)
+  GH_PRS_OPEN=$(echo "$prs" | jq 'length' 2>/dev/null || echo 0)
+  GH_ISSUE_NUMBERS=$(echo "$issues" | jq -r '.[] | "#\(.number)"' 2>/dev/null | tr '\n' ' ' | sed 's/ $//')
+
+  local human_items
+  human_items=$(jq -sr '
+    [ .[0][], .[1][] ]
+    | map(select(.labels | map(.name) | index("breeze:human")))
+    | length
+  ' <(echo "$issues") <(echo "$prs") 2>/dev/null || echo 0)
+  GH_HUMAN_ITEMS="$human_items"
+
+  # Stale claims: walk every open item with breeze:wip and ask claim.sh.
+  local wip_issue_numbers wip_pr_numbers
+  wip_issue_numbers=$(echo "$issues" | jq -r '.[] | select(.labels | map(.name) | index("breeze:wip")) | .number' 2>/dev/null || true)
+  wip_pr_numbers=$(echo "$prs" | jq -r '.[] | select(.labels | map(.name) | index("breeze:wip")) | .number' 2>/dev/null || true)
+  local n status
+  for n in $wip_issue_numbers $wip_pr_numbers; do
+    status=$(claim_check "$REPO" "$n" 2>/dev/null || echo "")
+    if [[ "$status" == "stale-claim" ]]; then
+      GH_STALE_CLAIMS=$((GH_STALE_CLAIMS + 1))
+    fi
+  done
+
+  if (( GH_ISSUES_OPEN == 0 && GH_PRS_OPEN == 0 )); then
+    GH_FINALIZED=true
+  fi
+}
+
+# ---- gather tick log -------------------------------------------------------
+# Emits:
+#   TICK_LOG_PATH = path (may or may not exist)
+#   TICK_LOG_LAST = last non-empty line, or ""
+
+gather_tick_log() {
+  TICK_LOG_PATH="$LOG"
+  TICK_LOG_LAST=""
+  if [[ -r "$LOG" ]]; then
+    TICK_LOG_LAST=$(awk 'NF' "$LOG" 2>/dev/null | tail -1 || true)
+  fi
+}
+
+# ---- render ----------------------------------------------------------------
+
+render_text() {
+  echo "bee status"
+  echo
+
+  # agent
+  local agent_line
+  if [[ "$AGENT_STATE" == "idle" ]]; then
+    agent_line="idle"
+  else
+    agent_line="running, pid=${AGENT_PID}"
+    if [[ -n "$AGENT_ROLE" ]]; then agent_line+=", role=${AGENT_ROLE}"; fi
+    if [[ -n "$AGENT_TARGET" ]]; then agent_line+=", target=${AGENT_TARGET}"; fi
+    if (( AGENT_CLAIMED_AGO >= 0 )); then
+      agent_line+=", claimed $(_fmt_duration "$AGENT_CLAIMED_AGO") ago"
+    fi
+  fi
+  printf 'agent:    %s\n' "$agent_line"
+
+  # launchd
+  local ld_line
+  if [[ "$LAUNCHD_STATE" == "not-installed" ]]; then
+    ld_line="not installed"
+  elif (( LAUNCHD_NEXT_TICK_SECS >= 0 )); then
+    local mins=$(( (LAUNCHD_NEXT_TICK_SECS + 30) / 60 ))
+    ld_line="loaded, next tick ~${mins}m"
+  else
+    ld_line="loaded"
+  fi
+  printf 'launchd:  %s\n' "$ld_line"
+
+  # github
+  local gh_line
+  if [[ "$GH_FINALIZED" == "true" ]]; then
+    gh_line="all clear — project finalized"
+  else
+    local issue_part="${GH_ISSUES_OPEN} issue"; (( GH_ISSUES_OPEN == 1 )) || issue_part="${GH_ISSUES_OPEN} issues"
+    issue_part+=" open"
+    if [[ -n "$GH_ISSUE_NUMBERS" ]]; then
+      issue_part+=" (${GH_ISSUE_NUMBERS// /, })"
+    fi
+    local pr_part="${GH_PRS_OPEN} PR"; (( GH_PRS_OPEN == 1 )) || pr_part="${GH_PRS_OPEN} PRs"
+    pr_part+=" open"
+    local stale_part="${GH_STALE_CLAIMS} stale claim"
+    (( GH_STALE_CLAIMS == 1 )) || stale_part="${GH_STALE_CLAIMS} stale claims"
+    gh_line="${issue_part}, ${pr_part}, ${stale_part}"
+    if (( GH_HUMAN_ITEMS > 0 )); then
+      gh_line+=", ${GH_HUMAN_ITEMS} breeze:human"
+    fi
+  fi
+  printf 'github:   %s\n' "$gh_line"
+
+  # tick log
+  if [[ -n "$TICK_LOG_LAST" ]]; then
+    printf 'tick log: %s (last line: %s)\n' "$TICK_LOG_PATH" "$TICK_LOG_LAST"
+  else
+    printf 'tick log: %s (empty)\n' "$TICK_LOG_PATH"
+  fi
+}
+
+render_json() {
+  # Build with jq so quoting is safe.
+  jq -n \
+    --arg agent_state "$AGENT_STATE" \
+    --arg agent_pid "$AGENT_PID" \
+    --arg agent_role "$AGENT_ROLE" \
+    --arg agent_target "$AGENT_TARGET" \
+    --argjson agent_claimed_ago_secs "$AGENT_CLAIMED_AGO" \
+    --arg launchd_state "$LAUNCHD_STATE" \
+    --argjson launchd_next_tick_secs "$LAUNCHD_NEXT_TICK_SECS" \
+    --argjson issues_open "$GH_ISSUES_OPEN" \
+    --arg issue_numbers "$GH_ISSUE_NUMBERS" \
+    --argjson prs_open "$GH_PRS_OPEN" \
+    --argjson stale_claims "$GH_STALE_CLAIMS" \
+    --argjson human_items "$GH_HUMAN_ITEMS" \
+    --argjson finalized "$([[ "$GH_FINALIZED" == "true" ]] && echo true || echo false)" \
+    --arg tick_log_path "$TICK_LOG_PATH" \
+    --arg tick_log_last "$TICK_LOG_LAST" \
+    '{
+      agent: {
+        state: $agent_state,
+        pid: (if $agent_pid == "" then null else ($agent_pid | tonumber) end),
+        role: (if $agent_role == "" then null else $agent_role end),
+        target: (if $agent_target == "" then null else $agent_target end),
+        claimed_ago_secs: (if $agent_claimed_ago_secs < 0 then null else $agent_claimed_ago_secs end)
+      },
+      launchd: {
+        state: $launchd_state,
+        next_tick_secs: (if $launchd_next_tick_secs < 0 then null else $launchd_next_tick_secs end)
+      },
+      github: {
+        issues_open: $issues_open,
+        issue_numbers: ($issue_numbers | if . == "" then [] else split(" ") end),
+        prs_open: $prs_open,
+        stale_claims: $stale_claims,
+        human_items: $human_items,
+        finalized: $finalized
+      },
+      tick_log: {
+        path: $tick_log_path,
+        last_line: (if $tick_log_last == "" then null else $tick_log_last end)
+      }
+    }'
+}
+
+cmd_status() {
+  local fmt="text"
+  case "${1:-}" in
+    "") ;;
+    --json) fmt="json" ;;
+    *) echo "bee status: unknown flag: $1" >&2; usage >&2; exit 2 ;;
+  esac
+
+  gather_agent
+  gather_launchd
+  gather_github
+  gather_tick_log
+
+  if [[ "$fmt" == "json" ]]; then
+    render_json
+  else
+    render_text
+  fi
+
+  if (( GH_HUMAN_ITEMS > 0 )); then
+    exit 1
+  fi
+  exit 0
+}
+
+main() {
+  local cmd="${1:-help}"
+  shift || true
+  case "$cmd" in
+    status)       cmd_status "$@" ;;
+    help|-h|--help) usage ;;
+    *) echo "bee: unknown command: $cmd" >&2; usage >&2; exit 2 ;;
+  esac
+}
+
+main "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,7 +60,28 @@ ensure_label "breeze:wip"   "e4e669" "Agent has claimed this item"
 ensure_label "breeze:done"  "0e8a16" "All work for this item is complete"
 ensure_label "breeze:human" "d93f0b" "Agent gave up; needs human"
 
-# 4. launchd plist
+# 4. bee CLI on PATH
+step "exposing bee CLI on PATH"
+BEE_SRC="$REPO_ROOT/scripts/bee"
+chmod +x "$BEE_SRC" 2>/dev/null || true
+# Pick the first directory of these that exists on PATH. No auto-mkdir.
+BEE_LINK_DIR=""
+for candidate in "$HOME/.local/bin" "$HOME/bin" "/usr/local/bin" "/opt/homebrew/bin"; do
+  if [[ -d "$candidate" ]] && printf '%s' ":$PATH:" | grep -qF ":$candidate:"; then
+    BEE_LINK_DIR="$candidate"
+    break
+  fi
+done
+if [[ -n "$BEE_LINK_DIR" ]]; then
+  BEE_LINK="$BEE_LINK_DIR/bee"
+  ln -sf "$BEE_SRC" "$BEE_LINK"
+  ok "bee -> $BEE_LINK"
+else
+  warn "no writable PATH dir found (tried ~/.local/bin, ~/bin, /usr/local/bin, /opt/homebrew/bin)"
+  warn "  add one to PATH, then: ln -sf $BEE_SRC <dir>/bee"
+fi
+
+# 5. launchd plist
 step "installing launchd plist"
 PLIST_NAME="com.serenakeyitan.git-bee.plist"
 PLIST_SRC="$REPO_ROOT/launchd/$PLIST_NAME"
@@ -78,7 +99,7 @@ launchctl unload "$PLIST_DST" 2>/dev/null || true
 launchctl load "$PLIST_DST"
 ok "launchd plist loaded: $PLIST_DST"
 
-# 5. First tick (optional)
+# 6. First tick (optional)
 if [[ "${SKIP_FIRST_TICK:-0}" != "1" ]]; then
   step "running first tick (use SKIP_FIRST_TICK=1 to skip)"
   "$REPO_ROOT/scripts/tick.sh" || warn "first tick exited non-zero (check ~/.git-bee/tick.log)"
@@ -90,6 +111,7 @@ $(printf '\033[1;32m')git-bee installed.$(printf '\033[0m')
 
 Next:
   • Open a design-doc issue:   gh issue create --repo $REPO --template design-doc
+  • Check current state:       bee status
   • Watch the tick log:        tail -f ~/.git-bee/tick.log
   • Uninstall:                 launchctl unload $PLIST_DST
 


### PR DESCRIPTION
Fixes #5

## Summary
- New `scripts/bee` — pure bash + gh + jq, read-only. Subcommands: `status`, `status --json`, `help`.
- Output matches the three-section block in the design doc: `agent`, `launchd`, `github`, plus a tick log tail.
- `scripts/install.sh` now symlinks `bee` into the first writable user-PATH dir (`~/.local/bin`, `~/bin`, `/usr/local/bin`, `/opt/homebrew/bin`). Warns if none are on PATH — no auto-mkdir, no silent PATH manipulation.
- `docs/runbook.md` documents the command, exit codes, and env overrides.
- Stale-claim detection reuses `scripts/claim.sh` (no logic duplication).
- Designed to be extensible: `bee claim`, `bee release`, `bee watch` can slot in later as subcommands without re-plumbing the dispatcher.

## Exit codes
- `0` — agent idle or running cleanly
- `1` — any open item has `breeze:human`
- `2` — usage error

## Local smoke
- `bee help` / `bee` / `bee bogus` — help + usage errors work.
- `bee status` (with this drafter agent live) prints `agent: running, pid=…, role=drafter, target=#5, claimed HH:MM:SS ago`.
- `GIT_BEE_LOCK=/missing bee status` — prints `agent: idle`.
- `bee status --json | jq .` — valid JSON with nested `agent` / `launchd` / `github` / `tick_log`.
- Unknown flag on `status` — exits 2 with usage.
- `bee` invoked via symlink (both absolute and relative, plus a chained link) — resolves the real script dir and sources `claim.sh` correctly.

## Test plan (E2E sandbox will run these)
- [ ] Onboarding (cold start): fresh clone → `./scripts/install.sh` → `bee status` returns cleanly
- [ ] PATH-install path: after `install.sh`, invoke `bee status` via the planted symlink (not `./scripts/bee`) — must not fail to source `claim.sh`
- [ ] Agent idle path: tick exits idle → `bee status` shows `idle`
- [ ] Agent running path: simulated PID lock → `bee status` shows `running`
- [ ] Stale claim detection: issue with `breeze:wip` but no marker → `bee status` reports 1 stale claim
- [ ] `--json` output parses with expected fields
- [ ] No issues, no PRs → `all clear — project finalized`
- [ ] `breeze:human` present → exits 1

🤖 Drafted by git-bee drafter agent.
