### PR TITLE
PR 1: mechanical finalization-gate check + stale-wip hygiene

### DIFF
--- a/agents/drafter.md
+++ b/agents/drafter.md
@@ -14,6 +14,10 @@ Given a design-doc issue, turn it into shipped code.
 6. Set `breeze:wip` on items you're actively working. Remove it when you hand off or finish.
 7. When all linked PRs are merged, label the design-doc issue `breeze:done` and close it.
 
+## Finalization gate
+
+Do NOT re-read the finalization gate yourself — `scripts/tick.sh` runs `scripts/gate-check.sh` before dispatching you and only wakes you when the gate is open (or doesn't apply). If you were dispatched, the gate is open; go do the work. Reading the gate line from the body and forming an independent judgment is the hallucination failure mode that burned ten cycles on issue #7 on 2026-04-19 — don't repeat it.
+
 ## Rules
 
 - **One PR per problem.** Do not bundle unrelated changes.

--- a/scripts/claim.sh
+++ b/scripts/claim.sh
@@ -97,6 +97,10 @@ claim_acquire() {
 }
 
 claim_release() {
+  # Callers (tick.sh) wire this into `trap ... EXIT INT TERM HUP` so that a
+  # Ctrl-C, launchd unload, or non-zero exit still drops `breeze:wip`. SIGKILL
+  # can't be trapped — stale claims from that path are cleared by the next
+  # tick via claim_check's TTL check (CLAIM_TTL_SECONDS, default 2h).
   local repo="$1" number="$2" agent="$3"
   # Only release if the claim is ours. Prevents one agent dropping another's lock.
   if ! claim_is_mine "$repo" "$number" "$agent"; then

--- a/scripts/gate-check.sh
+++ b/scripts/gate-check.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# gate-check: verify a design-doc issue's finalization gate.
+#
+# Usage: gate-check.sh <owner/repo> <issue-number>
+#
+# Exit codes:
+#   0  gate open — last body edit (or original authorship) is by the repo owner
+#      AND the first checkbox under `## Finalization gate` is `[x]`. Dispatch ok.
+#   1  gate closed — checkbox unchecked, or body unreadable. Fail closed.
+#   2  gate ticked by non-owner — checkbox is `[x]` but the latest body author
+#      is not the repo owner. Bot-authored ticks don't count.
+#   3  not a design-doc issue — no `## Finalization gate` section. Caller
+#      decides policy (tick.sh treats this as "gate not applicable").
+#
+# Why GraphQL: GitHub's REST timeline API does not emit events for issue body
+# edits. `userContentEdits` on the issue node does — newest first.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: gate-check.sh <owner/repo> <issue-number>" >&2
+  exit 1
+fi
+
+REPO="$1"
+NUM="$2"
+OWNER="${REPO%%/*}"
+NAME="${REPO##*/}"
+
+body=$(gh issue view "$NUM" --repo "$REPO" --json body --jq '.body' 2>/dev/null || true)
+if [[ -z "$body" ]]; then
+  echo "gate-check: could not read body of $REPO#$NUM" >&2
+  exit 1
+fi
+
+# Extract the first checkbox line after `## Finalization gate`. We stop at the
+# next `##` heading so we don't accidentally read a checkbox from a later
+# section (the plan-confirmation gate has its own check).
+gate_line=$(awk '
+  /^## Finalization gate[[:space:]]*$/ { in_section = 1; next }
+  in_section && /^## / { exit }
+  in_section && /^[[:space:]]*-[[:space:]]*\[[ xX]\]/ { print; exit }
+' <<<"$body")
+
+if ! grep -qE '^## Finalization gate[[:space:]]*$' <<<"$body"; then
+  exit 3
+fi
+
+if [[ -z "$gate_line" ]]; then
+  echo "gate-check: '## Finalization gate' section has no checkbox in $REPO#$NUM" >&2
+  exit 1
+fi
+
+if ! [[ "$gate_line" =~ \[[xX]\] ]]; then
+  echo "gate-check: finalization checkbox not ticked in $REPO#$NUM" >&2
+  exit 1
+fi
+
+# Figure out who is responsible for the current body. If the body has been
+# edited, the latest editor owns it; otherwise the original author does.
+edit_info=$(gh api graphql \
+  -f query='query($o:String!,$n:String!,$i:Int!){repository(owner:$o,name:$n){issue(number:$i){author{login} userContentEdits(last:1){nodes{editor{login}}}}}}' \
+  -f o="$OWNER" -f n="$NAME" -F i="$NUM" 2>/dev/null || true)
+
+if [[ -z "$edit_info" ]]; then
+  echo "gate-check: GraphQL query failed for $REPO#$NUM" >&2
+  exit 1
+fi
+
+latest_editor=$(echo "$edit_info" | jq -r '.data.repository.issue.userContentEdits.nodes[0].editor.login // ""')
+original_author=$(echo "$edit_info" | jq -r '.data.repository.issue.author.login // ""')
+
+responsible="${latest_editor:-$original_author}"
+
+if [[ -z "$responsible" ]]; then
+  echo "gate-check: could not determine body author for $REPO#$NUM" >&2
+  exit 1
+fi
+
+if [[ "$responsible" != "$OWNER" ]]; then
+  echo "gate-check: finalization tick in $REPO#$NUM is by '$responsible', not repo owner '$OWNER'" >&2
+  exit 2
+fi
+
+exit 0

--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -140,6 +140,19 @@ pick_target() {
     if echo "$open_pr_bodies" | grep -qiE "(fixes|closes|resolves)[[:space:]]+#${n}\b"; then
       continue
     fi
+    # Mechanical finalization-gate check (design-doc issues only).
+    # Exit 0 = gate open, 1 = closed, 2 = ticked by non-owner, 3 = not a design doc.
+    # We silently skip (1) and (2); (3) means the gate doesn't apply and we dispatch.
+    if [[ -x "$HERE/gate-check.sh" ]]; then
+      set +e
+      "$HERE/gate-check.sh" "$REPO" "$n" >/dev/null 2>&1
+      gate_rc=$?
+      set -e
+      if [[ "$gate_rc" == "1" || "$gate_rc" == "2" ]]; then
+        log "skip: #$n gate-check rc=$gate_rc (closed or non-owner tick)"
+        continue
+      fi
+    fi
     echo "drafter $n"
     return
   done
@@ -171,7 +184,11 @@ release_all() {
   claim_release "$REPO" "$number" "$agent_id" 2>/dev/null || true
   rm -f "$LOCK"
 }
-trap release_all EXIT
+# EXIT fires for normal and non-zero exits. Trap SIGINT/TERM/HUP explicitly so
+# a Ctrl-C or launchd stop doesn't orphan `breeze:wip` + the PID lock; SIGKILL
+# can't be trapped (stale claims then clear on the next tick via
+# claim_check's TTL path).
+trap release_all EXIT INT TERM HUP
 
 role_prompt_file="$REPO_ROOT/agents/${kind}.md"
 if [[ ! -f "$role_prompt_file" ]]; then

--- a/tests/e2e/verify.sh
+++ b/tests/e2e/verify.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# PR 1 E2E verify — gate-check + stale-wip hygiene.
+#
+# Contract (design doc, "Cross-cutting expectations"):
+#   - Prints exactly one JSON line at the end: {"passed": N, "total": M}.
+#   - Exit 0 regardless of pass/fail count — the JSON line is the verdict.
+#   - Idempotent — re-running in the same tree produces the same verdict.
+#   - Cleans up temp files on EXIT/INT/TERM.
+#   - Uses only bash, gh, jq, git (no Python/Node/installs).
+#
+# Isolates gh calls via a PATH-overriding `gh` stub that reads fixtures under
+# `tests/fixtures/gate-check/`. This keeps cases (a)–(d) deterministic without
+# a live API round-trip. Cases (e)–(f) exercise the tick.sh wiring and the
+# claim.sh release trap; they run against the real scripts with stub gh.
+
+set -u  # -e intentionally off — we want to count test failures, not abort.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+FIX_DIR="$REPO_ROOT/tests/fixtures/gate-check"
+
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/gitbee-pr1-verify.XXXXXX")
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT INT TERM HUP
+
+passed=0
+total=0
+
+pass() { passed=$((passed+1)); total=$((total+1)); echo "  PASS: $1"; }
+fail() { total=$((total+1)); echo "  FAIL: $1"; }
+
+# ---- gh stub ---------------------------------------------------------------
+# The stub reads $GH_STUB_FIXTURE (a dir) and dispatches on the command shape.
+# Supported calls (what gate-check.sh and tick.sh actually issue):
+#   gh issue view <n> --repo <r> --json body --jq '.body'    → cat body.md
+#   gh issue view <n> --repo <r> --json body                 → wrap body in JSON
+#   gh api graphql -f query=... (userContentEdits)           → cat edits.json
+# Anything else → exit 99 (unexpected call surfaces as a test failure).
+make_gh_stub() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+  cat >"$bin_dir/gh" <<'STUB'
+#!/usr/bin/env bash
+set -u
+args=("$@")
+case "${args[0]:-}" in
+  issue)
+    # `gh issue view <n> --repo <r> --json body [--jq '.body']`
+    wants_jq=0
+    for a in "${args[@]}"; do [[ "$a" == "--jq" ]] && wants_jq=1; done
+    if [[ "$wants_jq" == 1 ]]; then
+      cat "$GH_STUB_FIXTURE/body.md"
+    else
+      jq -Rs '{body: .}' <"$GH_STUB_FIXTURE/body.md"
+    fi
+    exit 0
+    ;;
+  api)
+    # `gh api graphql -f query=... -f o=... -f n=... -F i=...`
+    cat "$GH_STUB_FIXTURE/edits.json"
+    exit 0
+    ;;
+esac
+echo "gh stub: unexpected call: ${args[*]}" >&2
+exit 99
+STUB
+  chmod +x "$bin_dir/gh"
+}
+
+run_gate() {
+  local fixture="$1"
+  local bin_dir="$TMP/bin-$fixture"
+  make_gh_stub "$bin_dir"
+  GH_STUB_FIXTURE="$FIX_DIR/$fixture" PATH="$bin_dir:$PATH" \
+    bash "$REPO_ROOT/scripts/gate-check.sh" owner/repo 1 >/dev/null 2>&1
+  echo $?
+}
+
+echo "== PR 1 E2E: gate-check + stale-wip hygiene =="
+
+# (a) owner-ticked → exit 0
+[[ "$(run_gate owner-ticked)" == "0" ]] \
+  && pass "(a) owner-ticked gate → exit 0" \
+  || fail "(a) owner-ticked gate → exit 0"
+
+# (b) unticked → exit 1
+[[ "$(run_gate unticked)" == "1" ]] \
+  && pass "(b) unticked gate → exit 1" \
+  || fail "(b) unticked gate → exit 1"
+
+# (c) ticked-by-bot → exit 2
+[[ "$(run_gate bot-ticked)" == "2" ]] \
+  && pass "(c) bot-ticked gate → exit 2" \
+  || fail "(c) bot-ticked gate → exit 2"
+
+# (d) no Finalization gate section → exit 3 (not-applicable; tick.sh still dispatches).
+# Note: design doc sketched exit 1 here, but that would block non-design issues
+# (smoke tests, etc.) from ever being drafted. Exit 3 is "gate not applicable".
+[[ "$(run_gate no-section)" == "3" ]] \
+  && pass "(d) no gate section → exit 3 (not applicable)" \
+  || fail "(d) no gate section → exit 3 (not applicable)"
+
+# (e) tick.sh wiring: the drafter issue-loop branch in pick_target() calls
+# gate-check.sh and skips on rc=1|2. Asserted by grep — cheaper and more
+# stable than spawning the full pick_target() against a stubbed github.
+grep -q 'gate-check.sh' "$REPO_ROOT/scripts/tick.sh" \
+  && grep -q 'gate_rc' "$REPO_ROOT/scripts/tick.sh" \
+  && pass "(e) tick.sh calls gate-check.sh in drafter issue loop" \
+  || fail "(e) tick.sh calls gate-check.sh in drafter issue loop"
+
+# (f) stale breeze:wip hygiene: claim.sh documents that tick.sh wires the
+# release into EXIT+INT+TERM+HUP, and the TTL fallback handles SIGKILL.
+# We assert the wiring is in place.
+grep -qE 'trap +release_all +EXIT +INT +TERM +HUP' "$REPO_ROOT/scripts/tick.sh" \
+  && pass "(f) tick.sh trap covers EXIT/INT/TERM/HUP for claim release" \
+  || fail "(f) tick.sh trap covers EXIT/INT/TERM/HUP for claim release"
+
+# (g) Cold-start / onboarding coverage: a fresh clone can run verify.sh
+# end-to-end with only bash + gh + jq + git. Implemented by re-running this
+# script against a shallow clone of HEAD in a temp dir. Inner runs set
+# COLD_RUN=1 and skip (g) to avoid infinite recursion.
+if [[ "${COLD_RUN:-0}" == "1" ]]; then
+  pass "(g) cold-start — skipped in inner recursion"
+elif git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  cold="$TMP/cold"
+  # shallow local clone of the current working tree — does not hit the network
+  if git clone --quiet --depth 1 "$REPO_ROOT" "$cold" 2>/dev/null; then
+    # Some of this PR's files are only in the working tree until commit; copy
+    # them over so the cold clone can run verify.sh against them. Post-commit
+    # the `git clone` alone suffices (this is a no-op if the files are already
+    # in the clone's HEAD).
+    cp -R "$REPO_ROOT/tests" "$cold/" 2>/dev/null || true
+    cp "$REPO_ROOT/scripts/gate-check.sh" "$cold/scripts/" 2>/dev/null || true
+    cp "$REPO_ROOT/scripts/tick.sh" "$cold/scripts/" 2>/dev/null || true
+    cp "$REPO_ROOT/scripts/claim.sh" "$cold/scripts/" 2>/dev/null || true
+    if [[ -x "$cold/tests/e2e/verify.sh" ]] \
+       && verdict=$(COLD_RUN=1 bash "$cold/tests/e2e/verify.sh" 2>/dev/null | tail -1) \
+       && [[ -n "$verdict" ]] \
+       && echo "$verdict" | jq -e 'type == "object" and (.total | type == "number") and .total >= 6' >/dev/null 2>&1; then
+      pass "(g) cold-start clone runs verify.sh and emits JSON verdict"
+    else
+      fail "(g) cold-start clone runs verify.sh and emits JSON verdict"
+    fi
+  else
+    fail "(g) cold-start clone could not be created"
+  fi
+else
+  fail "(g) cold-start clone — not inside a git work tree"
+fi
+
+# Final verdict — exactly one JSON line, per the contract.
+printf '{"passed": %d, "total": %d}\n' "$passed" "$total"
+exit 0

--- a/tests/fixtures/gate-check/bot-ticked/body.md
+++ b/tests/fixtures/gate-check/bot-ticked/body.md
@@ -1,0 +1,7 @@
+## Finalization gate
+
+- [x] **design finalized — agent may proceed**
+
+## Rest
+
+A bot ticked the box above.

--- a/tests/fixtures/gate-check/bot-ticked/edits.json
+++ b/tests/fixtures/gate-check/bot-ticked/edits.json
@@ -1,0 +1,1 @@
+{"data":{"repository":{"issue":{"author":{"login":"owner"},"userContentEdits":{"nodes":[{"editor":{"login":"some-bot"}}]}}}}}

--- a/tests/fixtures/gate-check/no-section/body.md
+++ b/tests/fixtures/gate-check/no-section/body.md
@@ -1,0 +1,5 @@
+# Smoke test issue
+
+This one has no Finalization gate section at all.
+
+- [ ] a checkbox that is not a gate

--- a/tests/fixtures/gate-check/no-section/edits.json
+++ b/tests/fixtures/gate-check/no-section/edits.json
@@ -1,0 +1,1 @@
+{"data":{"repository":{"issue":{"author":{"login":"owner"},"userContentEdits":{"nodes":[]}}}}}

--- a/tests/fixtures/gate-check/owner-ticked/body.md
+++ b/tests/fixtures/gate-check/owner-ticked/body.md
@@ -1,0 +1,7 @@
+## Finalization gate
+
+- [x] **design finalized — agent may proceed**
+
+## Why this redesign
+
+Anything could go here.

--- a/tests/fixtures/gate-check/owner-ticked/edits.json
+++ b/tests/fixtures/gate-check/owner-ticked/edits.json
@@ -1,0 +1,1 @@
+{"data":{"repository":{"issue":{"author":{"login":"owner"},"userContentEdits":{"nodes":[{"editor":{"login":"owner"}}]}}}}}

--- a/tests/fixtures/gate-check/unticked/body.md
+++ b/tests/fixtures/gate-check/unticked/body.md
@@ -1,0 +1,7 @@
+## Finalization gate
+
+- [ ] **design finalized — agent may proceed**
+
+## Rest
+
+Irrelevant.

--- a/tests/fixtures/gate-check/unticked/edits.json
+++ b/tests/fixtures/gate-check/unticked/edits.json
@@ -1,0 +1,1 @@
+{"data":{"repository":{"issue":{"author":{"login":"owner"},"userContentEdits":{"nodes":[{"editor":{"login":"owner"}}]}}}}}


### PR DESCRIPTION
Fixes #7 — first of nine PRs in the milestone plan.

## Summary

- Move the finalization-gate check out of the drafter's prompt and into `scripts/gate-check.sh`, which `tick.sh` runs before dispatching drafter.
- Widen the claim-release trap in `tick.sh` to `EXIT+INT+TERM+HUP` so Ctrl-C or `launchctl unload` also drops `breeze:wip` + the PID lock (SIGKILL still relies on the existing 2h TTL path in `claim.sh`).
- Strip the "re-read the gate yourself" cue from `agents/drafter.md` — the exact cue that made drafter hallucinate "checkbox unchecked" on issue #7 across ~10 runs today.

## Why this is PR 1

PR 1 in the plan (issue #7) is explicitly a bug fix: drafter was hallucinating the gate state and burning cron cycles. The plan also says PRs 1–2 ship with drafter-authored light E2E (the supervisor layer lands in PR 2, so the birth chain can't supervise itself).

## Deviations from the plan sketch

Two, both surfaced here so a reviewer doesn't have to reverse-engineer them:

1. **Timeline vs GraphQL.** The sketch called for `gh api /repos/{owner}/{repo}/issues/{n}/timeline` to find the last body-edit event. The REST timeline endpoint does not emit body-edit events (verified: `["commented","labeled","referenced","unlabeled"]` on issue #7). The GraphQL `userContentEdits` connection does. Gate-check uses it.
2. **Missing gate section.** The sketch said missing-section → exit 1 (fail-closed). Left as-is that would block the repo's existing non-design issues (smoke tests, etc.) from ever being drafted. Missing-section is now exit 3 "not applicable" and `tick.sh` treats it the same as "dispatch normally". Design-doc invariant still holds: any issue with a `## Finalization gate` section whose first checkbox is `[ ]` returns exit 1.

## Test plan

`tests/e2e/verify.sh` runs 7 deterministic cases with a PATH-overriding `gh` stub reading fixtures under `tests/fixtures/gate-check/`:

- [x] (a) owner-ticked → exit 0
- [x] (b) unticked → exit 1
- [x] (c) bot-ticked (latest body editor ≠ owner) → exit 2
- [x] (d) no `## Finalization gate` section → exit 3 (not-applicable)
- [x] (e) `tick.sh` wires `gate-check.sh` into the drafter issue loop
- [x] (f) `tick.sh` trap covers EXIT+INT+TERM+HUP for `release_all`
- [x] (g) cold-start: verify.sh is runnable from a fresh clone with only bash+gh+jq+git

Verdict emitted as the single required JSON line: `{"passed": 7, "total": 7}`.

## Files

- `scripts/gate-check.sh` (new, ~85 lines)
- `scripts/tick.sh` (+18/-1)
- `scripts/claim.sh` (+4, doc comment on trap coverage — no behavior change)
- `agents/drafter.md` (+4, points at mechanical check)
- `tests/e2e/verify.sh` (new, ~153 lines)
- `tests/fixtures/gate-check/{owner-ticked,unticked,bot-ticked,no-section}/{body.md,edits.json}` (8 fixture files)

Total diff ~294 lines, within the 100–500 PR size rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)