### PR TITLE
fix: resolve sandbox path to prevent URL malformation

### DIFF
--- a/scripts/e2e-sandbox.sh
+++ b/scripts/e2e-sandbox.sh
@@ -84,6 +84,8 @@ EOF
 
 cmd_step() {
   local sandbox_path="$1" desc="$2" cmd="$3"
+  # Resolve to absolute path to avoid issues with relative paths like "."
+  sandbox_path=$(cd "$sandbox_path" && pwd)
   cd "$sandbox_path"
   local num
   num=$(_next_step_num "$sandbox_path")
@@ -133,6 +135,8 @@ EOF
 
 cmd_skip() {
   local sandbox_path="$1" desc="$2" reason="$3"
+  # Resolve to absolute path to avoid issues with relative paths like "."
+  sandbox_path=$(cd "$sandbox_path" && pwd)
   cd "$sandbox_path"
   local num
   num=$(_next_step_num "$sandbox_path")
@@ -149,6 +153,8 @@ cmd_skip() {
 
 cmd_finalize() {
   local sandbox_path="$1" result="$2" reason="${3:-}"
+  # Resolve to absolute path to avoid issues with relative paths like "."
+  sandbox_path=$(cd "$sandbox_path" && pwd)
   cd "$sandbox_path"
   local pr_number
   pr_number=$(jq -r '.pr_number' .meta.json)


### PR DESCRIPTION
## Summary
- Fixes malformed sandbox URL in E2E finalize comments
- Resolves paths to absolute to prevent basename issues with relative paths

## Problem
When `scripts/e2e-sandbox.sh finalize` was called with `.` as the path, it produced malformed URL like `https://github.com/serenakeyitan/.` instead of the proper sandbox repository URL.

## Solution
- Resolve `sandbox_path` to absolute path using `$(cd "$sandbox_path" && pwd)` in all cmd functions
- This ensures `basename` correctly extracts the sandbox directory name
- Applied consistently to `cmd_step`, `cmd_skip`, and `cmd_finalize`

## Testing
- Tested that basename returns correct value for absolute paths
- Verified that `.` as input gets resolved to proper directory name

Fixes #9 (part 3/4 - sandbox URL malformation)