### PR TITLE
feat(agents): require role-prefix + verdict headers on agent comments

### DIFF
--- a/agents/drafter.md
+++ b/agents/drafter.md
@@ -20,6 +20,7 @@ Do NOT re-read the finalization gate yourself — `scripts/tick.sh` runs `script
 
 ## Rules
 
+- **Prefix every comment you author with a role header.** Because all bee agents post as the same GitHub account, your comments must be self-identifying. Start every issue comment, PR description, and PR comment with `**drafter:**` (or `**drafter: done**` when handing off, `**drafter: plan**` when posting a milestone plan, `**drafter: design**` when posting a design draft) on its own first line, then a blank line, then the body. Does not apply to commit messages or code itself.
 - **One PR per problem.** Do not bundle unrelated changes.
 - **Never skip tests.** If tests fail, fix them — do not disable or `--no-verify`.
 - **Stop after 5 failed attempts.** Use `bee pause <n> "<reason>"` to label `breeze:human` and explain what you tried.

--- a/agents/e2e.md
+++ b/agents/e2e.md
@@ -36,6 +36,7 @@ Use `scripts/e2e-sandbox.sh`. Do NOT hand-write commits, repo creation, or the f
 
 ## Rules
 
+- **Prefix any ad-hoc comment with `**e2e:**`.** Because all bee agents post as the same GitHub account, any PR/issue comment you author outside the sandbox script must start with `**e2e:**` on its own first line (e.g. `**e2e:** starting sandbox for PR #N`). The canonical `**E2E trace (pass|fail)**` comment emitted by `finalize` already identifies itself and does not need an extra prefix.
 - **Always use the script.** Do not create sandbox repos with other names, do not post your own E2E comment, do not write `## E2E: pass` or similar — the merger parser only recognizes `**E2E trace (pass)**` (emitted by `finalize`).
 - **Every step gets a commit.** Skipped steps get a commit too. No silent skipping.
 - **No mocks of the thing being tested.** If the design says "calls the API," you call the API. Mock only peripherals.

--- a/agents/merger.md
+++ b/agents/merger.md
@@ -8,6 +8,11 @@ When a PR is approved AND has a passing E2E trace, merge it.
 
 ## Rules
 
+- **Prefix every comment you author.** Because all bee agents post as the same GitHub account, every issue/PR comment you author must start on its first line with one of:
+  - `**merger: merged**` (successful merge)
+  - `**merger: skipped — <reason>**` (skipping with a stated reason)
+  - `**merger: paused**` (handing off to human via `bee pause`)
+  Then a blank line, then the body.
 - **Only merge if:**
   - `reviewDecision == "APPROVED"` *or* a review body contains `<!-- bee:approved-for-e2e -->`
   - A PR comment exists that matches the E2E-pass pattern: body contains `**E2E trace (pass)**` and a sandbox URL
@@ -16,7 +21,7 @@ When a PR is approved AND has a passing E2E trace, merge it.
 - **After merge:** scan the PR body for `Fixes #N` / `Closes #N`. For each linked issue:
   - Label `breeze:done`
   - Close if not already closed
-  - Comment: `Implemented by PR #<pr>. Merged at <sha>.`
+  - Comment: `**merger: merged**\n\nImplemented by PR #<pr>. Merged at <sha>.`
 - **Never re-open a merged PR** or un-label anything. Merger is a one-way door.
 
 ## When blocked

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -15,9 +15,14 @@ When an implementation PR is opened or updated, post a normal prose review comme
 
 ## Rules
 
-- **Write prose, not verdicts.** No `ALIGNED / CONFLICT` labels. Just a normal GitHub review comment like a human reviewer would write.
-- **Approve, request changes, or comment.** Use `gh pr review --approve`, `--request-changes`, or `--comment`. Default to `--comment` unless you're confident.
-- **Self-authored PRs can't be approved via GitHub.** If the PR author is the same GitHub account as your auth identity, `--approve` fails. In that case: post a `--comment` review whose body contains the literal marker `<!-- bee:approved-for-e2e -->` on its own line. The tick treats that marker as approval-equivalent and routes to the E2E agent.
+- **Lead with a verdict header.** Every review body starts on its first line with one of:
+  - `**reviewer verdict: approved**`
+  - `**reviewer verdict: changes-requested**`
+  - `**reviewer verdict: comment**`
+  Then a blank line, then prose. Because all bee agents post as the same GitHub account, this header is how humans and other agents tell roles + decisions apart at a glance.
+- **Write prose, not verdict tables.** No `ALIGNED / CONFLICT` labels. After the header, write a normal GitHub review comment like a human reviewer would write.
+- **Approve, request changes, or comment.** Use `gh pr review --approve`, `--request-changes`, or `--comment`. Default to `--comment` unless you're confident. The header verdict must match the `gh pr review` flag.
+- **Self-authored PRs can't be approved via GitHub.** If the PR author is the same GitHub account as your auth identity, `--approve` fails. In that case: post a `--comment` review whose body starts with `**reviewer verdict: approved**` and also contains the literal marker `<!-- bee:approved-for-e2e -->` on its own line. The tick treats that marker as approval-equivalent and routes to the E2E agent.
 - **Do not push fixes yourself.** You are the reviewer. The drafter handles feedback on its next tick.
 - **Do not merge.** Even on approve, merging is the drafter's job (or the human's).
 - **One review per PR state.** If you already reviewed at the current HEAD SHA, skip. Re-review only when new commits land.


### PR DESCRIPTION
## Summary

- Every agent-authored comment, review, or PR body must now start on its first line with a role + verdict header.
- Disambiguates author identity when all four agents post as the same GitHub account.
- Makes reviews self-describing at a glance instead of burying the verdict in prose.

## Headers by role

| Role | Header |
|---|---|
| reviewer | \`**reviewer verdict: approved**\` / \`**reviewer verdict: changes-requested**\` / \`**reviewer verdict: comment**\` |
| drafter | \`**drafter:**\` / \`**drafter: done**\` / \`**drafter: plan**\` / \`**drafter: design**\` |
| e2e | \`**e2e:**\` on ad-hoc comments (sandbox's \`**E2E trace (pass\|fail)**\` is already self-identifying) |
| merger | \`**merger: merged**\` / \`**merger: skipped — <reason>**\` / \`**merger: paused**\` |

Fixes #21

## Test plan

- [ ] Next drafter run posts comments starting with \`**drafter:**\`
- [ ] Next reviewer run starts review body with a \`**reviewer verdict: ...**\` line
- [ ] Next merger run's close-comment starts with \`**merger: merged**\`

---

🐝 Generated by git-bee ([#21](https://github.com/serenakeyitan/git-bee/issues/21))

🤖 Generated with [Claude Code](https://claude.com/claude-code)