### PR TITLE
docs: flowchart improvements (human-edit loop + pause path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,22 +15,24 @@ An autonomous agent that buzzes through GitHub issues on a schedule, picks up un
   └───────┬───────────────┘                               │
           │ yes                                           │
           ▼                                               │
-  🐝 drafter appends milestone plan to issue              │
-          │                                               │
-          ▼                                               │
-  ┌───────────────────────┐                               │
-  │ plan finalized?   ────┼─── no ──► drafter revises ────┤
-  └───────┬───────────────┘                               │
-          │ yes                                           │
-          ▼                                               │
-  🐝 drafter opens implementation PR ◄────────────────────┘
+  🐝 drafter appends milestone plan to issue ◄────────────┘
+          │                                      ▲
+          ▼                                      │
+  ┌───────────────────────┐                      │
+  │ plan finalized?   ────┼── no ──► human edits ┤
+  │                       │          (drafter    │
+  │                       │           re-plans)  │
+  └───────┬───────────────┘                      │
+          │ yes                                  │
+          ▼                                      │
+  🐝 drafter opens implementation PR ◄───────────┘
           │                          ▲
           ▼                          │
   🐝 reviewer reviews PR             │
           │                          │
           ▼                          │
   ┌───────────────────────┐          │
-  │ approved?         ────┼── no ────┘  (drafter addresses feedback)
+  │ approved?         ────┼── no ────┘ (drafter addresses feedback)
   └───────┬───────────────┘
           │ yes
           ▼
@@ -38,7 +40,7 @@ An autonomous agent that buzzes through GitHub issues on a schedule, picks up un
           │
           ▼
   ┌───────────────────────┐
-  │ E2E passes?       ────┼── no ────► drafter fixes, re-enters loop
+  │ E2E passes?       ────┼── no ──► drafter fixes, re-enters loop
   └───────┬───────────────┘
           │ yes
           ▼
@@ -52,7 +54,26 @@ An autonomous agent that buzzes through GitHub issues on a schedule, picks up un
           ▼
       ✅ project shipped
 
-  Any agent gives up after 5 tries → ⚠ breeze:human (paused for human)
+
+  Pause paths (any agent can exit the loop by elevating to human):
+
+  🐝 <agent> stuck (5 failed tries, ambiguous design, external blocker)
+          │
+          ▼
+  runs `bee pause <n> "<reason>"` which atomically:
+    1. adds `breeze:human` label to the issue/PR
+    2. posts a **<role>: paused** comment with the reason
+    3. removes the agent's `breeze:wip` claim
+    4. exits cleanly
+          │
+          ▼
+  👤 human reads comment, unblocks by one of:
+    • edits the issue/PR to resolve the ambiguity
+    • removes `breeze:human` to hand back to agents
+    • comments with guidance and removes the label
+          │
+          ▼
+  next tick re-dispatches an agent on the same item
 ```
 
 ## How it works


### PR DESCRIPTION
**drafter:**

## Summary

Two flowchart fixes in the README:

1. **Human-edit at a gate loops back to drafter re-plan.** Before: the \"human edits issue\" arrow skipped past the milestone-plan step on the way to PR open. Since the plan is derived from the design, a design edit must trigger a re-plan — now both gate loops route through \`drafter appends milestone plan\` again.

2. **Pause/elevate path is now a real mini-flow.** Before: one line \"any agent gives up after 5 tries → ⚠ breeze:human\". Now shows the four atomic steps of \`bee pause\` (add label, post reason comment, release \`breeze:wip\`, exit) and the human's three unblock options.

Fixes #25

## Test plan

- [ ] View the README on github.com/serenakeyitan/git-bee and verify the ASCII flowchart renders cleanly in the code fence
- [ ] Confirm the two loops (design-edit and plan-edit) both route back through the drafter-plan step
- [ ] Confirm the pause mini-flow is visually grouped below the main happy path

---

🐝 Generated by git-bee ([#25](https://github.com/serenakeyitan/git-bee/issues/25))

🤖 Generated with [Claude Code](https://claude.com/claude-code)