### PR TITLE
statusline: drop issue/PR number lists

### DIFF
--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -88,31 +88,25 @@ if [[ -x "$BEE_SCRIPT" ]]; then
     next_tick=$(printf '%s\n' "$launchd_raw" | grep -oE '[0-9]+m([0-9]+s)?|[0-9]+s' | head -1)
     [[ -z "$next_tick" ]] && next_tick="?"
 
-    # Open issue/PR numbers + paused count, cached
+    # Paused count (breeze:human-labeled items), cached.
     now=$(date +%s)
     use_cache=0
     if [[ -f "$CACHE_FILE" ]]; then
       cached_epoch=$(sed -n '1p' "$CACHE_FILE" 2>/dev/null)
       if [[ -n "$cached_epoch" ]] && (( now - cached_epoch < CACHE_TTL )); then
-        issues_list=$(sed -n '2p' "$CACHE_FILE")
-        prs_list=$(sed -n '3p' "$CACHE_FILE")
-        paused_count=$(sed -n '4p' "$CACHE_FILE")
+        paused_count=$(sed -n '2p' "$CACHE_FILE")
         use_cache=1
       fi
     fi
     if (( use_cache == 0 )); then
-      issues_list=$(gh issue list --repo "$REPO" --state open --json number --jq '[.[].number | "#\(.)"] | join(",")' 2>/dev/null || echo "?")
-      prs_list=$(gh pr list --repo "$REPO" --state open --json number --jq '[.[].number | "#\(.)"] | join(",")' 2>/dev/null || echo "?")
       paused_issues=$(gh issue list --repo "$REPO" --state open --label "breeze:human" --json number --jq 'length' 2>/dev/null || echo 0)
       paused_prs=$(gh pr list --repo "$REPO" --state open --label "breeze:human" --json number --jq 'length' 2>/dev/null || echo 0)
       paused_count=$(( paused_issues + paused_prs ))
-      printf '%s\n%s\n%s\n%s\n' "$now" "$issues_list" "$prs_list" "$paused_count" > "$CACHE_FILE"
+      printf '%s\n%s\n' "$now" "$paused_count" > "$CACHE_FILE"
     fi
-    [[ -z "$issues_list" ]] && issues_list="none"
-    [[ -z "$prs_list" ]] && prs_list="none"
     [[ -z "$paused_count" ]] && paused_count=0
 
-    bee_line="🐝 git-bee: ${state} · next ${next_tick} · issues: ${issues_list} · PRs: ${prs_list}"
+    bee_line="🐝 git-bee: ${state} · next ${next_tick}"
     if (( paused_count > 0 )); then
       bee_line="${bee_line} · ⚠ ${paused_count} paused"
     fi


### PR DESCRIPTION
**drafter:**

## Summary

Drops the \`issues: #X,#Y · PRs: #Z\` segments from line 1. They ate most of the line, duplicated what GitHub's tabs show, never changed in a meaningful way, and cost two extra API calls per refresh.

Line 1 becomes:
\`\`\`
🐝 git-bee: merging #24 · next 47s
\`\`\`

With \`⚠ N paused\` appended when \`breeze:human\` count > 0 (unchanged).

Fixes #27

## Test plan

- [x] Local run: \`rm /tmp/git-bee-statusline-cache && bash scripts/statusline.sh\` → shows \`🐝 git-bee: idle after merging #24 · next 26s\` (no issue/PR list)
- [ ] Verify \`⚠ N paused\` still appears when there's a \`breeze:human\` item
- [ ] Confirm line 2 (\`/breeze: ...\`) renders unchanged

---

🐝 Generated by git-bee ([#27](https://github.com/serenakeyitan/git-bee/issues/27))

🤖 Generated with [Claude Code](https://claude.com/claude-code)