### PR TITLE
statusline: show 'next: after agent' while an agent runs

### DIFF
--- a/scripts/bee
+++ b/scripts/bee
@@ -267,6 +267,8 @@ render_text() {
   local ld_line
   if [[ "$LAUNCHD_STATE" == "not-installed" ]]; then
     ld_line="not installed"
+  elif [[ "$AGENT_STATE" == "running" ]]; then
+    ld_line="loaded, next: after agent"
   elif (( LAUNCHD_NEXT_TICK_SECS >= 0 )); then
     if (( LAUNCHD_NEXT_TICK_SECS < 60 )); then
       ld_line="loaded, next tick ~${LAUNCHD_NEXT_TICK_SECS}s"

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -86,7 +86,7 @@ if [[ -x "$BEE_SCRIPT" ]]; then
     fi
 
     if [[ "$launchd_raw" == *"after agent"* ]]; then
-      next_tick="after agent"
+      next_tick="after ${role:-agent}"
     else
       next_tick=$(printf '%s\n' "$launchd_raw" | grep -oE '[0-9]+m([0-9]+s)?|[0-9]+s' | head -1)
       [[ -z "$next_tick" ]] && next_tick="?"

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -85,8 +85,12 @@ if [[ -x "$BEE_SCRIPT" ]]; then
       state="$last_done"
     fi
 
-    next_tick=$(printf '%s\n' "$launchd_raw" | grep -oE '[0-9]+m([0-9]+s)?|[0-9]+s' | head -1)
-    [[ -z "$next_tick" ]] && next_tick="?"
+    if [[ "$launchd_raw" == *"after agent"* ]]; then
+      next_tick="after agent"
+    else
+      next_tick=$(printf '%s\n' "$launchd_raw" | grep -oE '[0-9]+m([0-9]+s)?|[0-9]+s' | head -1)
+      [[ -z "$next_tick" ]] && next_tick="?"
+    fi
 
     # Paused count (breeze:human-labeled items), cached.
     now=$(date +%s)


### PR DESCRIPTION
Fixes #32

## Summary
- `bee status` and the statusline both showed `~0s` / `next 0s` during the entire duration of an agent run, because launchd can't fire while the lock is held and the countdown clamps to zero.
- Short-circuit both views to `next: after agent` when `AGENT_STATE=running`.

## Test plan
- [x] `rm /tmp/git-bee-statusline-cache && bash scripts/statusline.sh` during a live run → renders `next after agent`
- [ ] Verify display returns to `~Ns`/`~Nm` once the agent completes