### PR TITLE
fix(merger): verify E2E trace matches current PR HEAD SHA

### DIFF
--- a/agents/merger.md
+++ b/agents/merger.md
@@ -16,6 +16,7 @@ When a PR is approved AND has a passing E2E trace, merge it.
 - **Only merge if:**
   - `reviewDecision == "APPROVED"` *or* a review body contains `<!-- bee:approved-for-e2e -->`
   - A PR comment exists that matches the E2E-pass pattern: body contains `**E2E trace (pass)**` and a sandbox URL
+  - The E2E trace comment's sandbox short-SHA matches the PR's current HEAD short-SHA
   - The PR is mergeable (no conflicts, CI green if any)
 - **Use squash merge** with the PR title as the commit subject: `gh pr merge <n> --squash --delete-branch`.
 - **After merge:** scan the PR body for `Fixes #N` / `Closes #N`. For each linked issue:
@@ -37,4 +38,4 @@ Same as other agents — acquire `breeze:wip` on the PR before merging. Release 
 
 ## Output
 
-`merger: pr=<n> action=<merged|skipped-not-approved|skipped-no-e2e|skipped-conflicts|skipped-already-merged|gave-up-breeze-human>`.
+`merger: pr=<n> action=<merged|skipped-not-approved|skipped-no-e2e|skipped-stale-e2e|skipped-conflicts|skipped-already-merged|gave-up-breeze-human>`.


### PR DESCRIPTION
**drafter:**

## Summary

This PR fixes a security issue where the merger agent could merge PRs with new commits that haven't been E2E tested.

## Problem

As observed on PR #20, when a new commit was pushed after E2E testing completed, the merger agent merged it anyway without verifying that the E2E trace matched the current HEAD SHA. This creates a hole where substantive changes could be merged without verification.

## Solution

Added SHA verification to the merger agent rules:
- The merger now checks that the E2E trace comment's sandbox short-SHA matches the PR's current HEAD short-SHA
- If they don't match, it skips with `skipped-stale-e2e` to let the next tick dispatch a fresh E2E run
- Added the new skip reason to the output format

## Changes

- Updated `agents/merger.md` to add the SHA verification rule
- Added `skipped-stale-e2e` to the list of possible output actions

Fixes #23