### PR TITLE
fix(statusline): preserve bee output when status exits 1

### DIFF
--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -15,7 +15,10 @@ REPO="serenakeyitan/git-bee"
 # ── 1. bee line ──────────────────────────────────────────────────────────────
 bee_line="🐝 git-bee: offline"
 if [[ -x "$BEE_SCRIPT" ]]; then
-  bee_out=$("$BEE_SCRIPT" status 2>/dev/null) || bee_out=""
+  # `bee status` exits 1 when breeze:human items exist — capture output
+  # regardless of exit code, otherwise the statusline goes silent exactly
+  # when there's something interesting to show.
+  bee_out=$("$BEE_SCRIPT" status 2>/dev/null || true)
   if [[ -n "$bee_out" ]]; then
     agent_raw=$(printf '%s\n' "$bee_out" | grep -i '^agent:' | head -1 | sed 's/^agent:[[:space:]]*//')
     launchd_raw=$(printf '%s\n' "$bee_out" | grep -i '^launchd:' | head -1)


### PR DESCRIPTION
## Summary
- `bee status` exits 1 on `breeze:human` items (by design, for scripts)
- Statusline wrapper was treating that exit code as failure and blanking the output
- One-char change: `|| bee_out=""` → `|| true`

Closes #531

## Test plan
- [x] With a `breeze:human`-labeled issue open, statusline now shows agent state instead of "offline"
- [x] With no such items, no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)