### PR TITLE
fix(statusline): replace 'next ?' with meaningful labels

### DIFF
--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -87,9 +87,11 @@ if [[ -x "$BEE_SCRIPT" ]]; then
 
     if [[ "$launchd_raw" == *"after agent"* ]]; then
       next_tick="after ${role:-agent}"
+    elif [[ "$launchd_raw" == *"not installed"* ]]; then
+      next_tick="launchd off"
     else
       next_tick=$(printf '%s\n' "$launchd_raw" | grep -oE '[0-9]+m([0-9]+s)?|[0-9]+s' | head -1)
-      [[ -z "$next_tick" ]] && next_tick="?"
+      [[ -z "$next_tick" ]] && next_tick="pending"
     fi
 
     # Paused count (breeze:human-labeled items), cached.


### PR DESCRIPTION
## Summary
- \`not installed\` → \`next launchd off\`
- \`loaded\` with no next-tick yet → \`next pending\`
- The \`?\` case is now unreachable

Closes #533

## Test plan
- [x] With launchd not loaded: statusline shows \`next launchd off\`
- [x] With launchd loaded and a tick pending: statusline shows the countdown as before
- [x] While an agent is running: \`next after <role>\` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)