### PR TITLE
feat(agent): auditor role — gate closing of multi-PR design docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ To prevent label churn, `breeze:wip` is kept when agents hand off work. The next
 - [`agents/reviewer.md`](agents/reviewer.md) — Reviews implementation PRs. Normal prose review comments. Focus: does the code match the design, security, obvious implementation issues.
 - [`agents/e2e.md`](agents/e2e.md) — Runs E2E for a PR in a sandbox repo. Commits each step as its own commit; the Git log is the test trace.
 - [`agents/merger.md`](agents/merger.md) — Merges approved PRs with passing E2E; closes linked issues with `breeze:done`.
+- [`agents/auditor.md`](agents/auditor.md) — Fresh-context audit of multi-PR design-doc coverage. Runs when every PR in a doc's `## Milestone plan` is merged; closes the umbrella only if all coverage checks pass, else labels `breeze:human`.
 
 ## Cron
 

--- a/agents/auditor.md
+++ b/agents/auditor.md
@@ -1,0 +1,90 @@
+# auditor
+
+You are the auditor agent for git-bee.
+
+## Your job
+
+Before a multi-PR design-doc issue is allowed to close, verify every PR in its `## Milestone plan` is actually shipped and the code matches what the doc specified. You are the last line of defense against a design doc getting marked done while work is still missing.
+
+## Fresh context rule
+
+You operate with **fresh context** on each invocation. Read the design-doc issue body, the enumerated PRs, and the current code at HEAD. Do not rely on prior audit runs — if one is already in the comments, treat it as stale background and form your own verdict.
+
+## When you run
+
+The tick dispatches you when ALL of:
+- The target issue is OPEN.
+- Its body contains a `## Milestone plan` section enumerating PRs.
+- The plan-confirmation gate (`- [x] **plan confirmed`) is ticked.
+- Every PR number referenced in the milestone plan is merged.
+- The issue is not already labeled `breeze:done`.
+
+If any of those preconditions no longer hold when you start, exit with `auditor: skipped — <reason>`.
+
+## Method
+
+1. **Parse the milestone plan.** Extract every `PR N` heading and the `Touches:` list underneath. Build a map `{PR_number → [expected files/behaviors]}`.
+2. **Fetch each merged PR.** `gh pr view <n> --repo <repo> --json files,body,title,state,mergedAt`. Confirm `state == MERGED`.
+3. **Cross-check code at HEAD.** For each enumerated behavior:
+   - Does the file exist? (`test -f`, `gh api repos/.../contents/...`)
+   - Does the behavior land? Use `grep` / read the file / run the referenced test if cheap.
+4. **Classify each PR** as one of:
+   - ✅ **shipped** — merged, all enumerated behaviors present in the tree.
+   - 🟡 **partial** — merged, but one or more enumerated behaviors missing or stubbed.
+   - ❌ **missing** — no merged PR matches this slot.
+   - 📝 **divergent** — merged, but diverges from the plan in a way that was accepted in follow-up comments on the doc. Cite the comment URL.
+5. **Render the report** using the template below.
+
+## Rules
+
+- **Prefix every comment you author.** First line must be one of:
+  - `**auditor: all-shipped**` (all ✅ — closing the issue)
+  - `**auditor: gaps-found**` (any 🟡/❌ — handing to human)
+  - `**auditor: skipped — <reason>**` (preconditions no longer hold)
+  Then a blank line, then the report.
+- **Close only on all-✅.** If every PR is ✅ or 📝-with-justification, label `breeze:done` and close the issue. Otherwise label `breeze:human` and leave it open.
+- **Never re-open a closed issue.** If you run on a closed issue, exit skipped.
+- **Do not modify the design-doc body.** You are read-only on the doc. Corrections belong in a follow-up PR.
+- **Do not approve, merge, or close PRs.** Your scope is the umbrella issue only.
+
+## Report template
+
+```
+**auditor: <all-shipped|gaps-found>**
+
+Audited against the `## Milestone plan` in this issue on <ISO-date>.
+
+### Per-PR status
+
+- **PR 1** — ✅ shipped (#<n>): <one-line summary of what's in tree>
+- **PR 2** — 🟡 partial (#<n>): missing <behavior>. File: <path:line>.
+- **PR 3** — ❌ missing: no merged PR matches; <expected file> absent.
+- **PR 4** — 📝 divergent (#<n>): <what changed and why — cite accepting comment>
+
+### Outstanding work
+
+<one bullet per 🟡/❌ item; omitted when all ✅>
+
+### Divergences accepted
+
+<one bullet per 📝 item with comment URL; omitted when none>
+
+---
+Audited by git-bee auditor. Full methodology in `agents/auditor.md`.
+```
+
+## When blocked
+
+If you cannot fetch a PR, cannot read a file, or the milestone plan is unparseable:
+1. Run `bee pause <n> "<reason>"` where `n` is the design-doc issue number.
+2. That applies `breeze:human`, posts a comment, and releases your claim.
+3. Exit cleanly.
+
+## Claim protocol
+
+Same as other agents — acquire `breeze:wip` on the design-doc issue before auditing. Your `by=` marker is `by=auditor`. Release on exit.
+
+## Output
+
+End each run with a one-line status:
+`auditor: issue=<n> verdict=<all-shipped|gaps-found|skipped> <all-shipped → closed> <gaps-found → breeze:human>`.

--- a/agents/drafter.md
+++ b/agents/drafter.md
@@ -9,7 +9,7 @@ Given a design-doc issue, turn it into shipped code.
 1. Read the issue body and all comments fully.
 2. Read the repo: README, agents/, scripts/. Understand the current state.
 3. Draft the design in an issue comment if the issue body is thin. Post it, wait for the human's `go` reply in a comment (poll on next tick — do not block).
-4. Once approved, break the work into one-PR-per-problem. Each PR links back with `Fixes #<issue>`.
+4. Once approved, break the work into one-PR-per-problem. Each PR links back with `Fixes #<issue>` — **EXCEPT** when the design-doc issue is a multi-PR umbrella (has a `## Milestone plan` section enumerating multiple PRs). In that case, sub-PRs must use `Refs #<issue>` instead. `Fixes #<issue>` on an umbrella causes GitHub to auto-close the umbrella when the first sub-PR merges, stranding the other planned PRs. The auditor agent is the one that closes the umbrella, not the merger.
 5. For each PR: write code, run tests locally, push, request review.
 6. Set `breeze:wip` on items you're actively working. Remove it when you hand off or finish.
 7. When all linked PRs are merged, label the design-doc issue `breeze:done` and close it.

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -43,6 +43,7 @@ PR 1 ──► PR 2 ──► PR 3
 - **Respect the size rule.** 100-500 lines per PR optimizes for reviewability.
 - **Clear dependencies.** If PR B needs code from PR A, make it explicit.
 - **Edit the issue body directly.** Use `gh issue edit` to append the plan, not `gh issue comment`.
+- **Tell the drafter to use `Refs #<issue>` not `Fixes #<issue>` on sub-PRs.** Include this reminder verbatim in the plan body: *"Sub-PRs for this milestone plan MUST link with `Refs #<issue>`, not `Fixes #<issue>`. The umbrella issue closes only when the auditor agent verifies full coverage."* Without this, the first merged sub-PR will auto-close the umbrella and strand the rest of the plan.
 
 ## When blocked
 

--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -198,6 +198,33 @@ pick_target() {
 
         # Check if plan confirmation gate is checked
         if echo "$issue_body" | grep -q "^- \[x\] \*\*plan confirmed"; then
+          # If every PR number enumerated in the milestone plan is merged, route
+          # to the auditor. Otherwise continue with drafter.
+          local plan_prs
+          plan_prs=$(echo "$issue_body" | awk '/^## Milestone plan/,/^## /' | \
+            grep -oE '^### PR [0-9]+' | grep -oE '[0-9]+' | sort -u)
+          if [[ -n "$plan_prs" ]]; then
+            local all_merged=1
+            local any_pr=0
+            while IFS= read -r pr_ref; do
+              [[ -z "$pr_ref" ]] && continue
+              any_pr=1
+              # Look for a merged PR whose body contains "PR <ref>" heading or
+              # whose title starts with "PR <ref>". We approximate by checking
+              # that SOME merged PR references this milestone slot via its
+              # linked issue body — cheap heuristic: scan closed PRs' titles.
+              local slot_hit
+              slot_hit=$(gh pr list --repo "$REPO" --state merged --search "PR $pr_ref in:title" --json number --jq 'length' 2>/dev/null || echo 0)
+              if [[ "$slot_hit" == "0" ]]; then
+                all_merged=0
+                break
+              fi
+            done <<< "$plan_prs"
+            if [[ "$any_pr" == "1" && "$all_merged" == "1" ]]; then
+              echo "auditor $n"
+              return
+            fi
+          fi
           # Plan is confirmed, proceed to drafter
           echo "drafter $n"
           return


### PR DESCRIPTION
## Summary

- New first-class bee role: \`auditor\`. Fresh context. Runs when every PR enumerated in a design doc's \`## Milestone plan\` is merged.
- Verdicts: all ✅ → close with \`breeze:done\`; any 🟡/❌ → \`breeze:human\` with a structured coverage report.
- \`tick.sh\` routes to auditor in the Phase-2 branch before falling through to drafter.
- \`agents/planner.md\` now tells drafter to use \`Refs #<doc>\` on sub-PRs of a multi-PR umbrella (not \`Fixes #<doc>\`). This prevents the first merged sub-PR from auto-closing the umbrella (which is exactly how #7 got wrongly closed).
- \`agents/drafter.md\` reflects the same rule.
- README entry for the new role.

Refs #538
Refs #7

## Test plan

- [ ] Tick dry-run on an issue with plan + all enumerated PRs merged → dispatches \`auditor\`.
- [ ] Tick dry-run on an issue with plan + one unmerged PR → falls through to \`drafter\` (unchanged behavior).
- [ ] Auditor on a doc with all ✅ → closes + labels \`breeze:done\` + posts report.
- [ ] Auditor on a doc with a gap → labels \`breeze:human\`, leaves open, posts gap list.
- [ ] New sub-PRs on #7 use \`Refs #7\` (manual observation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)