### PR TITLE
feat(e2e): canonical runner — NDJSON + crash-safe artifacts (PR6)

### DIFF
--- a/agents/e2e.md
+++ b/agents/e2e.md
@@ -12,7 +12,14 @@ You operate with **fresh context** on each invocation. Read the test plan and cu
 
 ## How
 
-Use `scripts/e2e-sandbox.sh`. Do NOT hand-write commits, repo creation, or the final comment — the script enforces naming, signing, the step schema, and the comment format that `tick.sh` greps for.
+Use `scripts/e2e-sandbox.sh` for the trace repo. For PRs that ship `tests/e2e/verify.sh`, ALSO run the canonical runner — it captures NDJSON and writes a crash-safe JSON artifact the supervisor can audit:
+
+```
+artifact=$(scripts/e2e-runner.sh <pr-checkout-path> <pr-sha>)
+# artifact is a path under ~/.git-bee/evals/<short-sha>-<ts>.json
+```
+
+Do NOT hand-write commits, repo creation, or the final comment — the script enforces naming, signing, the step schema, and the comment format that `tick.sh` greps for.
 
 1. Read the PR and its linked design-doc issue. Extract the list of verifiable steps from the PR's test plan / design doc.
 2. Create the sandbox:

--- a/scripts/e2e-runner.sh
+++ b/scripts/e2e-runner.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# git-bee E2E runner: canonical harness for invoking a PR's
+# tests/e2e/verify.sh. Captures stdout as an NDJSON transcript and writes
+# a crash-safe JSON artifact to ~/.git-bee/evals/<sha>-<ts>.json via
+# tmp+rename, so a SIGTERM mid-run can never leave a half-written file.
+#
+# Usage:
+#   e2e-runner.sh <pr-checkout-path> <pr-sha>
+#     → runs <pr-checkout-path>/tests/e2e/verify.sh
+#     → writes ~/.git-bee/evals/<short-sha>-<ts>.json
+#     → prints the artifact path on stdout
+#     → exit 0 if verify.sh ran to completion (even if cases failed)
+#     → exit 2 if verify.sh is missing
+#     → exit 1 on any other error
+#
+# The verify.sh contract (from the design doc):
+#   - Prints one JSON line at the end: {"passed": N, "total": M}
+#   - Exit 0 whether or not cases passed — the JSON line is the verdict
+#   - May print additional NDJSON lines before the verdict for per-case detail
+
+set -uo pipefail
+
+EVALS_DIR="${HOME}/.git-bee/evals"
+mkdir -p "$EVALS_DIR"
+
+usage() {
+  cat >&2 <<EOF
+usage: e2e-runner.sh <pr-checkout-path> <pr-sha>
+EOF
+  exit 64
+}
+
+[[ $# -eq 2 ]] || usage
+PR_PATH="$1"
+PR_SHA="$2"
+
+VERIFY="$PR_PATH/tests/e2e/verify.sh"
+if [[ ! -x "$VERIFY" ]]; then
+  if [[ -f "$VERIFY" ]]; then
+    chmod +x "$VERIFY"
+  else
+    echo "e2e-runner: missing $VERIFY" >&2
+    exit 2
+  fi
+fi
+
+SHORT_SHA="${PR_SHA:0:7}"
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+ARTIFACT="$EVALS_DIR/${SHORT_SHA}-${TS}.json"
+TMP="${ARTIFACT}.tmp.$$"
+TRANSCRIPT=$(mktemp)
+
+# Clean up temp file on any exit path so SIGTERM/SIGINT can't leave debris.
+cleanup() {
+  rm -f "$TRANSCRIPT" "$TMP"
+}
+trap cleanup EXIT INT TERM HUP
+
+START=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+set +e
+( cd "$PR_PATH" && bash "$VERIFY" ) > "$TRANSCRIPT" 2>&1
+VERIFY_EXIT=$?
+set -e
+END=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# Parse the verdict — the LAST valid JSON line that contains "passed" and "total".
+VERDICT_LINE=$(awk '
+  /^\{.*"passed".*"total".*\}$/ { last=$0 }
+  END { if (last) print last }
+' "$TRANSCRIPT")
+
+PASSED="null"
+TOTAL="null"
+if [[ -n "$VERDICT_LINE" ]]; then
+  PASSED=$(echo "$VERDICT_LINE" | jq -r '.passed // "null"' 2>/dev/null || echo "null")
+  TOTAL=$(echo "$VERDICT_LINE" | jq -r '.total // "null"' 2>/dev/null || echo "null")
+fi
+
+# Build the crash-safe artifact. Write to TMP first, then atomic rename.
+jq -n \
+  --arg sha "$PR_SHA" \
+  --arg short_sha "$SHORT_SHA" \
+  --arg started "$START" \
+  --arg ended "$END" \
+  --argjson exit_code "$VERIFY_EXIT" \
+  --arg verdict "$VERDICT_LINE" \
+  --argjson passed "$PASSED" \
+  --argjson total "$TOTAL" \
+  --rawfile transcript "$TRANSCRIPT" \
+  '{
+    sha: $sha,
+    short_sha: $short_sha,
+    started_at: $started,
+    ended_at: $ended,
+    verify_exit_code: $exit_code,
+    verdict_line: $verdict,
+    passed: $passed,
+    total: $total,
+    transcript: $transcript
+  }' > "$TMP"
+
+mv "$TMP" "$ARTIFACT"
+
+echo "$ARTIFACT"
+
+# Propagate nothing beyond "ran to completion" — the verdict is in the artifact,
+# not in the exit code. Callers inspect the JSON.
+exit 0


### PR DESCRIPTION
## Summary
- New \`scripts/e2e-runner.sh\`: invokes a PR's \`tests/e2e/verify.sh\`, captures NDJSON, writes \`~/.git-bee/evals/<short-sha>-<ts>.json\` via tmp+rename (crash-safe).
- Parses the \`{\"passed\":N,\"total\":M}\` verdict from the last matching line; records transcript + exit code regardless.
- Exit 2 on missing verify.sh (fail-closed).
- \`agents/e2e.md\` points at the runner for PRs that ship verify.sh. Sandbox script unchanged — trace repo consolidation is PR9.

Refs #541
Refs #7

## Test plan
- [x] Toy verify.sh producing NDJSON → artifact written with correct \`passed\`, \`total\`, \`verify_exit_code\`.
- [x] Missing verify.sh → exit 2 with clear message.
- [ ] SIGTERM mid-run leaves no half-written artifact (temp is cleaned, final never appears).

🤖 Generated with [Claude Code](https://claude.com/claude-code)