### PR TITLE
feat(tick): route on e2e-supervisor verdicts + trivial-patch procedure (PR7)

### DIFF
--- a/agents/e2e-supervisor.md
+++ b/agents/e2e-supervisor.md
@@ -66,9 +66,29 @@ You start fresh on every invocation. Read only the current PR's artifacts:
 
 Do NOT reference verdicts from other PRs or prior supervisor runs.
 
+## Canonical verdict markers
+
+Run-audit verdicts MUST use exactly one of these headers on the first line of your final comment. `scripts/tick.sh` parses these markers to route the next step — a typo in the header breaks routing.
+
+- `**e2e-supervisor: pass**`
+- `**e2e-supervisor: lazy-run**`
+- `**e2e-supervisor: code-bug**`
+- `**e2e-supervisor: test-bug**`
+- `**e2e-supervisor: design-trivial**` — posted immediately after you patch the design-doc body with `gh issue edit --body`.
+- `**e2e-supervisor: design-conflicting**` — followed by the Structured Brief template. Also apply `breeze:human` to the PR before exiting (`gh issue edit <pr> --add-label breeze:human`).
+
+Plan-review mode (Phase 2) uses its own headers; the routing table above is for run-audit only.
+
+## Trivial-patch procedure
+
+When you classify a run as `design-trivial`:
+1. Edit the design-doc issue body via `gh issue edit <n> --repo <repo> --body "$(printf ...)"` to append the one-line clarification under the existing design. Do NOT post a comment for the edit itself.
+2. Then post the `**e2e-supervisor: design-trivial**` verdict comment on the PR, linking to the edited issue and quoting the exact line you added.
+3. Release your `breeze:wip` on the PR. The next tick resumes the e2e loop.
+
 ## Rules
 
-- **Prefix every comment with `**e2e-supervisor:**`** (or specific variants like `**e2e-supervisor: approved**`).
+- **Prefix every comment with `**e2e-supervisor:**`** (or specific variants like `**e2e-supervisor: approved**`). Run-audit comments MUST use a canonical verdict marker exactly as listed above.
 - **Independent judgment.** Fresh eyes, no accumulated bias.
 - **Full audit.** Read every line of the trace, no shortcuts.
 - **Clear verdicts.** Each classification has a specific next action.

--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -94,6 +94,40 @@ pick_target() {
     return
   fi
 
+  # 1b'. PRs with a supervisor verdict — route based on the verdict. The
+  # `pass` verdict is covered by the approved+E2E-trace-pass route above,
+  # so here we only need to handle the five non-pass outcomes.
+  local supervised
+  supervised=$(echo "$pr_basics" | jq -r '
+    .[]
+    | . as $pr
+    | select($pr.labels | map(.name) | index("breeze:wip") | not)
+    | select($pr.labels | map(.name) | index("breeze:human") | not)
+    | ([$pr.comments[]? | select(.body // "" | test("\\*\\*e2e-supervisor: (pass|lazy-run|code-bug|test-bug|design-trivial|design-conflicting)\\*\\*"))]
+        | sort_by(.createdAt) | last) as $v
+    | select($v != null)
+    | ($v.body | capture("\\*\\*e2e-supervisor: (?<verdict>pass|lazy-run|code-bug|test-bug|design-trivial|design-conflicting)\\*\\*").verdict) as $vd
+    | "\($pr.number) \($vd)"
+  ' 2>/dev/null || true)
+  if [[ -n "$supervised" ]]; then
+    while IFS= read -r row; do
+      [[ -z "$row" ]] && continue
+      local pr_n="${row%% *}" vd="${row##* }"
+      case "$vd" in
+        lazy-run)  echo "e2e $pr_n"; return ;;
+        code-bug)  echo "drafter $pr_n"; return ;;
+        test-bug)  echo "e2e-designer $pr_n"; return ;;
+        design-conflicting)
+          # Belt-and-suspenders: supervisor should have applied breeze:human,
+          # but ensure it's labeled so this tick never re-dispatches.
+          gh issue edit "$pr_n" --repo "$REPO" --add-label "breeze:human" >/dev/null 2>&1 || true
+          log "skip: #$pr_n design-conflicting — labeled breeze:human, held for human"
+          ;;
+        design-trivial|pass) : ;;  # handled elsewhere / nothing to do
+      esac
+    done <<< "$supervised"
+  fi
+
   # 1c. Approved PRs without an E2E trace yet → E2E.
   local approved_prs
   approved_prs=$(echo "$pr_basics" | jq -r '


### PR DESCRIPTION
## Summary

- Tick now parses the most recent \`**e2e-supervisor: <verdict>**\` marker on a PR and routes:
  - \`lazy-run\` → e2e
  - \`code-bug\` → drafter
  - \`test-bug\` → e2e-designer
  - \`design-conflicting\` → apply \`breeze:human\`, hold
  - \`design-trivial\` → no-op (supervisor already patched + cleared wip)
  - \`pass\` → existing merger route (via \`**E2E trace (pass)**\` comment)
- Supervisor prompt gains a Canonical Verdict Markers section and an explicit Trivial-patch Procedure: edit the design-doc body via \`gh issue edit --body\`, then post the \`design-trivial\` comment and release wip.

Refs #543
Refs #7

## Test plan
- [ ] PR with \`**e2e-supervisor: code-bug**\` → tick routes to drafter.
- [ ] PR with \`**e2e-supervisor: design-conflicting**\` → tick labels \`breeze:human\`, no dispatch.
- [ ] PR with \`**e2e-supervisor: design-trivial**\` → tick is idle; supervisor's earlier body edit stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)