### PR TITLE
feat(agents): align labeling with breeze 4-state convention (no source/priority)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 *.log
 .env
 .env.local
+.claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# git-bee agent conventions
+
+Ported from breeze (`first-tree/src/products/breeze`). All agents MUST follow.
+
+## Label state machine
+
+Four labels, mutually exclusive. Precedence: **done > MERGED/CLOSED > human > wip > absent**.
+
+| Label | Meaning | Applied by |
+| --- | --- | --- |
+| `breeze:new` | Default. Absence of all `breeze:*` labels is the real "new" signal. | Human-readable only — never auto-applied. |
+| `breeze:wip` | An agent is actively working this item. | `claim.sh` on acquire; drafter when opening a PR. |
+| `breeze:human` | Needs human judgment. Tick dispatcher skips this. | Any agent via `bee pause`, supervisor `design-conflicting`, merger when stuck. |
+| `breeze:done` | Agent has finished. GitHub MERGED/CLOSED also implies done. | Rarely set explicitly — prefer closing the issue/PR. |
+
+### Rules
+
+- **Use the helper.** All transitions go through `set_breeze_state <repo> <num> <state>` in `scripts/labels.sh`, which atomically removes prior `breeze:*` labels. Never call `gh edit --add-label breeze:*` directly.
+- **Exactly one.** At any moment a non-closed item has zero or one `breeze:*` label. Two is a bug.
+- **Agent claims = `breeze:wip`.** `claim_acquire` in `scripts/claim.sh` already does this for issues; drafter must also set `breeze:wip` on PRs it opens.
+- **No other label namespaces.** Do NOT apply `source:*` or `priority:*` labels on issues or PRs. Source is internal (task kind). Priority is a dispatcher concern — if you need it, sort in `tick.sh`, don't label.
+- **`breeze:done` is rarely needed.** Closing the issue/PR is enough (GitHub's state derives done). Only set `breeze:done` explicitly when the agent has finished its part but the item stays open for downstream work.
+
+## Comment prefixes
+
+Every PR/issue comment an agent posts must start with `**<role>:**` on its own first line:
+
+- `**drafter:**`, `**reviewer:**`, `**e2e:**`, `**e2e-designer:**`, `**e2e-supervisor:**`, `**planner:**`, `**auditor:**`, `**merger:**`
+
+The canonical E2E trace comment (`**E2E trace (pass|fail)**`) emitted by `scripts/e2e-sandbox.sh finalize` is exempt — it identifies itself.
+
+## Claims
+
+Claim acquisition is label-based today (via `breeze:wip`) with a freshness comment marker. This differs from breeze (filesystem lockfiles) and is acceptable while git-bee is single-machine. See `scripts/claim.sh`.
+
+## When blocked
+
+Any agent that gets stuck must call `bee pause <n> "<reason>"`. That applies `breeze:human`, posts a comment, and releases the claim.

--- a/agents/auditor.md
+++ b/agents/auditor.md
@@ -42,7 +42,7 @@ If any of those preconditions no longer hold when you start, exit with `auditor:
   - `**auditor: gaps-found**` (any 🟡/❌ — handing to human)
   - `**auditor: skipped — <reason>**` (preconditions no longer hold)
   Then a blank line, then the report.
-- **Close only on all-✅.** If every PR is ✅ or 📝-with-justification, label `breeze:done` and close the issue. Otherwise label `breeze:human` and leave it open.
+- **Close only on all-✅.** If every PR is ✅ or 📝-with-justification, close the issue (GitHub-CLOSED derives `done` per the state machine — no `breeze:done` label needed). Otherwise transition the issue via `set_breeze_state <repo> <n> human` and leave it open. Never call `gh edit --add-label breeze:*` directly — see `AGENTS.md`.
 - **Never re-open a closed issue.** If you run on a closed issue, exit skipped.
 - **Do not modify the design-doc body.** You are read-only on the doc. Corrections belong in a follow-up PR.
 - **Do not approve, merge, or close PRs.** Your scope is the umbrella issue only.

--- a/agents/drafter.md
+++ b/agents/drafter.md
@@ -11,8 +11,8 @@ Given a design-doc issue, turn it into shipped code.
 3. Draft the design in an issue comment if the issue body is thin. Post it, wait for the human's `go` reply in a comment (poll on next tick — do not block).
 4. Once approved, break the work into one-PR-per-problem. Each PR links back with `Fixes #<issue>` — **EXCEPT** when the design-doc issue is a multi-PR umbrella (has a `## Milestone plan` section enumerating multiple PRs). In that case, sub-PRs must use `Refs #<issue>` instead. `Fixes #<issue>` on an umbrella causes GitHub to auto-close the umbrella when the first sub-PR merges, stranding the other planned PRs. The auditor agent is the one that closes the umbrella, not the merger.
 5. For each PR: write code, run tests locally, push, request review.
-6. Set `breeze:wip` on items you're actively working. Remove it when you hand off or finish.
-7. When all linked PRs are merged, label the design-doc issue `breeze:done` and close it.
+6. Set `breeze:wip` on items you're actively working via `set_breeze_state`. Remove/transition via the same helper when you hand off. Also set `breeze:wip` on every PR you **open** (the helper removes any prior `breeze:*` atomically). Never apply `source:*` or `priority:*` labels — see `AGENTS.md`.
+7. When all linked PRs are merged, close the design-doc issue (GitHub's MERGED/CLOSED state derives `done` automatically — you usually don't need to set `breeze:done` explicitly).
 
 ## Finalization gate
 
@@ -43,9 +43,10 @@ If you need human input or hit a blocker:
 ## Claim protocol
 
 Before touching an item:
-1. Check if `breeze:wip` is set - if it's fresh (labeled event < 2h old), another agent owns it. Skip.
-2. Otherwise: `gh issue edit <n> --add-label breeze:wip` to claim it.
-3. When done or handing off: remove the label with `gh issue edit <n> --remove-label breeze:wip`.
+1. Check if `breeze:wip` is set — if it's fresh (labeled event < 2h old), another agent owns it. Skip.
+2. Otherwise: source `scripts/labels.sh` and call `set_breeze_state <repo> <n> wip`. This atomically removes any prior `breeze:*` label.
+3. When you hand off back to the loop: either close the item (GitHub state derives `done`) or `set_breeze_state <repo> <n> human` / call `bee pause`.
+4. **Never** call `gh edit --add-label breeze:*` directly — always go through the helper so mutual exclusion is preserved.
 
 ## Output
 

--- a/agents/e2e-supervisor.md
+++ b/agents/e2e-supervisor.md
@@ -75,7 +75,7 @@ Run-audit verdicts MUST use exactly one of these headers on the first line of yo
 - `**e2e-supervisor: code-bug**`
 - `**e2e-supervisor: test-bug**`
 - `**e2e-supervisor: design-trivial**` — posted immediately after you patch the design-doc body with `gh issue edit --body`.
-- `**e2e-supervisor: design-conflicting**` — followed by the Structured Brief template. Also apply `breeze:human` to the PR before exiting (`gh issue edit <pr> --add-label breeze:human`).
+- `**e2e-supervisor: design-conflicting**` — followed by the Structured Brief template. Transition the PR to `breeze:human` before exiting: source `scripts/labels.sh` and call `set_breeze_state <repo> <pr> human`. Never call `gh edit --add-label breeze:*` directly (violates mutual-exclusion — see `AGENTS.md`).
 
 Plan-review mode (Phase 2) uses its own headers; the routing table above is for run-audit only.
 

--- a/scripts/labels.sh
+++ b/scripts/labels.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# git-bee label state-machine helper. Ports breeze's 4-state model.
+#
+# The four mutually-exclusive states:
+#   breeze:new     — absence of all breeze:* labels (human-readable only)
+#   breeze:wip     — agent is actively working
+#   breeze:human   — needs human input
+#   breeze:done    — agent finished (or GitHub MERGED/CLOSED implies this)
+#
+# Precedence: done > MERGED/CLOSED > human > wip > absent.
+#
+# Usage:
+#   source scripts/labels.sh
+#   set_breeze_state <repo> <number> <wip|human|done>
+#
+# Atomically removes any prior breeze:* label and applies exactly one.
+# Agents MUST use this for state transitions — do not call `gh edit
+# --add-label breeze:*` directly.
+
+# shellcheck disable=SC2155
+
+set_breeze_state() {
+  local repo="$1" number="$2" new_state="$3"
+  case "$new_state" in
+    wip|human|done) : ;;
+    *)
+      echo "set_breeze_state: invalid state '$new_state' (expected wip|human|done)" >&2
+      return 1
+      ;;
+  esac
+
+  # Discover current labels (works for both issues and PRs; gh routes by number).
+  local labels
+  labels=$(gh issue view "$number" --repo "$repo" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+
+  local to_remove=""
+  for state in wip human done; do
+    local lbl="breeze:${state}"
+    if [[ ",$labels," == *",${lbl},"* && "$state" != "$new_state" ]]; then
+      to_remove="${to_remove}${lbl},"
+    fi
+  done
+
+  if [[ -n "$to_remove" ]]; then
+    gh issue edit "$number" --repo "$repo" --remove-label "${to_remove%,}" >/dev/null 2>&1 || true
+  fi
+
+  local target="breeze:${new_state}"
+  if [[ ",$labels," != *",${target},"* ]]; then
+    gh issue edit "$number" --repo "$repo" --add-label "$target" >/dev/null 2>&1 || true
+  fi
+}
+
+# Remove ALL breeze:* labels. Used after terminal actions where the agent
+# wants the item to fall back to "new" (rare — mostly here for test cleanup).
+clear_breeze_state() {
+  local repo="$1" number="$2"
+  gh issue edit "$number" --repo "$repo" \
+    --remove-label "breeze:wip" \
+    --remove-label "breeze:human" \
+    --remove-label "breeze:done" >/dev/null 2>&1 || true
+}

--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -14,6 +14,8 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$HERE/.." && pwd)"
 # shellcheck disable=SC1091
 source "$HERE/claim.sh"
+# shellcheck disable=SC1091
+source "$HERE/labels.sh"
 
 REPO="serenakeyitan/git-bee"
 LOCK="/tmp/git-bee-agent.pid"
@@ -95,8 +97,7 @@ EOF
       local new_issue_n
       new_issue_n=$(echo "$new_issue_url" | grep -oE '/issues/[0-9]+' | grep -oE '[0-9]+' || echo "")
       if [[ -n "$new_issue_n" ]]; then
-        # shellcheck disable=SC1091
-        source "$HERE/labels.sh" && set_breeze_state "$REPO" "$new_issue_n" human
+        set_breeze_state "$REPO" "$new_issue_n" human
       fi
     else
       log "WARNING: Could not find a known-good SHA in tick history"
@@ -223,8 +224,7 @@ pick_target() {
         design-conflicting)
           # Belt-and-suspenders: supervisor should have applied breeze:human,
           # but ensure it's labeled so this tick never re-dispatches.
-          # shellcheck disable=SC1091
-          source "$HERE/labels.sh" && set_breeze_state "$REPO" "$pr_n" human
+          set_breeze_state "$REPO" "$pr_n" human
           log "skip: #$pr_n design-conflicting — labeled breeze:human, held for human"
           ;;
         design-trivial|pass) : ;;  # handled elsewhere / nothing to do

--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -86,10 +86,18 @@ The tick loop is now paused and will not dispatch agents until the ROLLBACK mark
 EOF
 )
 
-      gh issue create --repo "$REPO" \
+      # Create the issue and apply breeze:human via the labeling helper.
+      # We don't set priority:high — per AGENTS.md no auto-priority labels.
+      local new_issue_url
+      new_issue_url=$(gh issue create --repo "$REPO" \
         --title "Automatic rollback: 3 consecutive tick crashes detected" \
-        --body "$issue_body" \
-        --label "breeze:human,priority:high" 2>&1 | tee -a "$LOG" || true
+        --body "$issue_body" 2>&1 | tee -a "$LOG" | tail -1 || true)
+      local new_issue_n
+      new_issue_n=$(echo "$new_issue_url" | grep -oE '/issues/[0-9]+' | grep -oE '[0-9]+' || echo "")
+      if [[ -n "$new_issue_n" ]]; then
+        # shellcheck disable=SC1091
+        source "$HERE/labels.sh" && set_breeze_state "$REPO" "$new_issue_n" human
+      fi
     else
       log "WARNING: Could not find a known-good SHA in tick history"
     fi
@@ -215,7 +223,8 @@ pick_target() {
         design-conflicting)
           # Belt-and-suspenders: supervisor should have applied breeze:human,
           # but ensure it's labeled so this tick never re-dispatches.
-          gh issue edit "$pr_n" --repo "$REPO" --add-label "breeze:human" >/dev/null 2>&1 || true
+          # shellcheck disable=SC1091
+          source "$HERE/labels.sh" && set_breeze_state "$REPO" "$pr_n" human
           log "skip: #$pr_n design-conflicting — labeled breeze:human, held for human"
           ;;
         design-trivial|pass) : ;;  # handled elsewhere / nothing to do


### PR DESCRIPTION
Closes #553.

## Summary

Ports breeze's label state machine into git-bee. Agents were drifting: I filed issues with `source:notification` / `priority:high`, drafter opened PRs with no labels, and `tick.sh` auto-applied `priority:high` on crash-rollback issues. Breeze (in `first-tree/src/products/breeze`) uses exactly four labels (`breeze:new|wip|human|done`) with strict mutual exclusion — nothing else.

## Changes

- `scripts/labels.sh` — new helper `set_breeze_state <repo> <n> <wip|human|done>`. Atomically removes any prior `breeze:*` before applying the new one, preserving mutual exclusion.
- `AGENTS.md` (root) — canonical doc for the state machine. Precedence: **done > MERGED/CLOSED > human > wip > absent**. Prohibits `source:*` / `priority:*` on issues/PRs. `priority:high` is still read in `tick.sh`'s sort logic (humans can apply it), but no agent sets it.
- `scripts/tick.sh` — crash-rollback issue creation and supervisor `design-conflicting` handler both go through `set_breeze_state`. Drops auto-applied `priority:high`.
- `agents/drafter.md` — requires using the helper; drafter must set `breeze:wip` on PRs it opens (not just the parent issue).
- `agents/e2e-supervisor.md` — `design-conflicting` transition uses the helper.
- `agents/auditor.md` — close-on-all-✅ doesn't set `breeze:done` (GitHub-CLOSED derives done); gap path uses the helper for `breeze:human`.
- `.gitignore` — ignore `.claude/` worktree artifacts (linter was staging them).

## Test plan

- [x] `set_breeze_state foo 1 wrong` errors with validation.
- [x] Retro-cleaned: removed `source:notification` from issues #550, #553.
- [ ] Next agent-opened PR should land with `breeze:wip` from the drafter claim.

## Reference

- Breeze classifier: `first-tree/src/products/breeze/engine/runtime/classifier.ts`
- Breeze runner prompt: `first-tree/src/products/breeze/engine/daemon/runner.ts:141-189`

---
_Posted by git-bee drafter agent._