### PR TITLE
feat(activity): structured log + 'bee log' command

### DIFF
--- a/scripts/activity.sh
+++ b/scripts/activity.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# activity.sh — structured activity log for git-bee agents.
+#
+# Writes NDJSON events to ~/.git-bee/activity.ndjson. One line per event.
+#
+# Usage:
+#   scripts/activity.sh start <repo> <kind> <number> <agent_id>
+#   scripts/activity.sh end   <repo> <kind> <number> <agent_id> <exit_code> <duration_s>
+#
+# Event shape:
+#   {
+#     "ts": "2026-04-21T02:43:01Z",
+#     "event": "start" | "end",
+#     "agent": "reviewer",
+#     "agent_id": "reviewer-myhost",
+#     "repo": "serenakeyitan/git-bee",
+#     "target": "#561",
+#     "target_kind": "pr" | "issue",
+#     "title": "feat(...): ...",
+#     "umbrella": "#7",            // inferred from Refs/Fixes in PR body; null otherwise
+#     "exit_code": 0,              // end events only
+#     "duration_s": 108,           // end events only
+#     "outcome": "requested-changes" // end events only; parsed from last agent comment
+#   }
+#
+# Outcome is extracted from the last comment authored on the target whose body
+# starts with `**<agent>:` — e.g. "**reviewer: requested-changes**" yields
+# outcome="requested-changes". Best-effort — outcome is null if no such comment.
+
+set -uo pipefail
+
+LOG_DIR="${HOME}/.git-bee"
+ACTIVITY_LOG="${LOG_DIR}/activity.ndjson"
+mkdir -p "$LOG_DIR"
+
+now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+# Resolve target metadata: is_pr (bool), title, umbrella (#N or null).
+# One gh call — we fetch both PR and issue shape to handle either.
+resolve_target() {
+  local repo="$1" number="$2"
+  # Try PR first (cheaper — PRs are a subset of issues on GH)
+  local pr_json
+  pr_json=$(gh pr view "$number" --repo "$repo" --json title,body 2>/dev/null || echo "")
+  if [[ -n "$pr_json" ]]; then
+    local title umbrella
+    title=$(jq -r '.title // ""' <<<"$pr_json")
+    # Umbrella: first "Refs #N" or "Fixes #N" in body, N != this PR
+    umbrella=$(jq -r '.body // ""' <<<"$pr_json" | \
+      grep -oE '(Refs|Fixes|Closes) #[0-9]+' | \
+      head -1 | grep -oE '#[0-9]+' || true)
+    printf 'pr\t%s\t%s\n' "$title" "${umbrella:-}"
+    return
+  fi
+  # Fall back to issue
+  local issue_json
+  issue_json=$(gh issue view "$number" --repo "$repo" --json title 2>/dev/null || echo "")
+  if [[ -n "$issue_json" ]]; then
+    local title
+    title=$(jq -r '.title // ""' <<<"$issue_json")
+    printf 'issue\t%s\t\n' "$title"
+    return
+  fi
+  printf 'unknown\t\t\n'
+}
+
+# Scrape the last agent-prefixed body for an outcome token.
+#
+# Two sources, newest wins:
+#  1. Reviews on PRs (posted via `gh pr review`) — format
+#     "**reviewer verdict: <outcome>**" or "**<agent>: <outcome>**"
+#  2. Issue/PR comments — format "**<agent>: <outcome>**"
+#
+# Examples:
+#   "**reviewer verdict: changes-requested**" -> "changes-requested"
+#   "**e2e-supervisor: pass**"                -> "pass"
+#   "**merger: merged**"                      -> "merged"
+#   "**drafter: done**"                       -> "done"
+scrape_outcome() {
+  local repo="$1" number="$2" agent="$3"
+  local bodies=""
+  local reviews_json
+  reviews_json=$(gh pr view "$number" --repo "$repo" --json reviews 2>/dev/null || echo "")
+  if [[ -n "$reviews_json" ]]; then
+    local review_bodies
+    review_bodies=$(jq -r '[.reviews[]? | {ts: .submittedAt, body: (.body // "")}]' <<<"$reviews_json" 2>/dev/null || echo "[]")
+    bodies="$review_bodies"
+  fi
+  local comments_json
+  comments_json=$(gh issue view "$number" --repo "$repo" --json comments 2>/dev/null || echo "")
+  if [[ -n "$comments_json" ]]; then
+    local comment_bodies
+    comment_bodies=$(jq -r '[.comments[]? | {ts: .createdAt, body: (.body // "")}]' <<<"$comments_json" 2>/dev/null || echo "[]")
+    bodies=$(jq -s '.[0] + .[1]' <(echo "${bodies:-[]}") <(echo "$comment_bodies") 2>/dev/null || echo "[]")
+  fi
+  [[ -z "$bodies" || "$bodies" == "[]" ]] && { echo ""; return; }
+  # Sort by ts desc, pick first matching line.
+  # Matches: "**<agent>: foo**" or "**<agent> verdict: foo**"
+  # Agent-specific parsers fall through to the generic "**<agent>: <outcome>**"
+  # pattern. e2e is special: the outcome is posted as "**E2E trace (<outcome>)**"
+  # in a summary comment, not as the e2e agent's own message.
+  local outcome=""
+  if [[ "$agent" == "e2e" ]]; then
+    outcome=$(jq -r '
+      sort_by(.ts) | reverse
+      | map(.body)
+      | map(select(. | test("^\\*\\*E2E trace \\(")))
+      | .[0] // ""
+      | capture("^\\*\\*E2E trace \\((?<out>[^)]+)\\)") // {out: ""}
+      | .out
+    ' <<<"$bodies" 2>/dev/null || echo "")
+  fi
+  if [[ -z "$outcome" ]]; then
+    # Require at least one non-* non-whitespace char after the colon —
+    # otherwise it's a generic "**drafter:**" header with no outcome token.
+    outcome=$(jq -r --arg agent "$agent" '
+      sort_by(.ts) | reverse
+      | map(.body)
+      | map(select(. | test("^\\*\\*" + $agent + "( verdict)?:\\s*[^*\\s]")))
+      | .[0] // ""
+      | capture("^\\*\\*" + $agent + "( verdict)?:\\s*(?<out>[^*\\n]+)") // {out: ""}
+      | .out
+      | gsub("\\s+\\*\\*.*$"; "")
+      | gsub("^\\s+|\\s+$"; "")
+    ' <<<"$bodies" 2>/dev/null || echo "")
+  fi
+  echo "$outcome"
+}
+
+write_event() {
+  local json="$1"
+  printf '%s\n' "$json" >> "$ACTIVITY_LOG"
+}
+
+cmd_start() {
+  local repo="$1" kind="$2" number="$3" agent_id="$4"
+  local meta target_kind title umbrella
+  meta=$(resolve_target "$repo" "$number")
+  target_kind=$(cut -f1 <<<"$meta")
+  title=$(cut -f2 <<<"$meta")
+  umbrella=$(cut -f3 <<<"$meta")
+
+  local json
+  json=$(jq -cn \
+    --arg ts "$(now_iso)" \
+    --arg agent "$kind" \
+    --arg agent_id "$agent_id" \
+    --arg repo "$repo" \
+    --arg target "#${number}" \
+    --arg target_kind "$target_kind" \
+    --arg title "$title" \
+    --arg umbrella "$umbrella" \
+    '{
+      ts: $ts,
+      event: "start",
+      agent: $agent,
+      agent_id: $agent_id,
+      repo: $repo,
+      target: $target,
+      target_kind: $target_kind,
+      title: $title,
+      umbrella: (if $umbrella == "" then null else $umbrella end)
+    }')
+  write_event "$json"
+}
+
+cmd_end() {
+  local repo="$1" kind="$2" number="$3" agent_id="$4" exit_code="$5" duration_s="$6"
+  local meta target_kind title umbrella outcome
+  meta=$(resolve_target "$repo" "$number")
+  target_kind=$(cut -f1 <<<"$meta")
+  title=$(cut -f2 <<<"$meta")
+  umbrella=$(cut -f3 <<<"$meta")
+  outcome=$(scrape_outcome "$repo" "$number" "$kind")
+
+  local json
+  json=$(jq -cn \
+    --arg ts "$(now_iso)" \
+    --arg agent "$kind" \
+    --arg agent_id "$agent_id" \
+    --arg repo "$repo" \
+    --arg target "#${number}" \
+    --arg target_kind "$target_kind" \
+    --arg title "$title" \
+    --arg umbrella "$umbrella" \
+    --arg outcome "$outcome" \
+    --argjson exit_code "$exit_code" \
+    --argjson duration_s "$duration_s" \
+    '{
+      ts: $ts,
+      event: "end",
+      agent: $agent,
+      agent_id: $agent_id,
+      repo: $repo,
+      target: $target,
+      target_kind: $target_kind,
+      title: $title,
+      umbrella: (if $umbrella == "" then null else $umbrella end),
+      exit_code: $exit_code,
+      duration_s: $duration_s,
+      outcome: (if $outcome == "" then null else $outcome end)
+    }')
+  write_event "$json"
+}
+
+case "${1:-}" in
+  start) shift; cmd_start "$@" ;;
+  end)   shift; cmd_end "$@" ;;
+  *)
+    echo "usage: activity.sh start <repo> <kind> <number> <agent_id>" >&2
+    echo "       activity.sh end   <repo> <kind> <number> <agent_id> <exit_code> <duration_s>" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/bee
+++ b/scripts/bee
@@ -627,11 +627,113 @@ cmd_watch() {
   esac
 }
 
+cmd_log() {
+  local activity_log="$HOME/.git-bee/activity.ndjson"
+  if [[ ! -f "$activity_log" ]]; then
+    echo "bee log: no activity yet ($activity_log missing)" >&2
+    exit 0
+  fi
+
+  local limit=20 agent_filter="" target_filter="" since_filter="" raw=0
+  while (( $# > 0 )); do
+    case "$1" in
+      -n)          limit="$2"; shift 2 ;;
+      --agent)     agent_filter="$2"; shift 2 ;;
+      --target)    target_filter="$2"; shift 2 ;;
+      --since)     since_filter="$2"; shift 2 ;;
+      --raw)       raw=1; shift ;;
+      -h|--help)
+        cat <<USAGE
+usage: bee log [-n N] [--agent <name>] [--target #N] [--since <duration>] [--raw]
+
+  -n N           Show at most N events (default 20).
+  --agent NAME   Filter by agent (drafter, reviewer, e2e, merger, ...).
+  --target #N    Filter by issue/PR number (with or without #).
+  --since DUR    Relative time filter. Examples: 30m, 2h, 1d.
+  --raw          Print NDJSON lines instead of the pretty view.
+USAGE
+        exit 0 ;;
+      *) echo "bee log: unknown flag: $1" >&2; exit 2 ;;
+    esac
+  done
+
+  local since_epoch=0
+  if [[ -n "$since_filter" ]]; then
+    local num unit
+    num=$(echo "$since_filter" | grep -oE '^[0-9]+' || echo "")
+    unit=$(echo "$since_filter" | grep -oE '[a-zA-Z]+$' || echo "")
+    [[ -z "$num" || -z "$unit" ]] && { echo "bee log: bad --since value: $since_filter" >&2; exit 2; }
+    local secs=0
+    case "$unit" in
+      s|sec|secs|second|seconds) secs=$num ;;
+      m|min|mins|minute|minutes) secs=$(( num * 60 )) ;;
+      h|hr|hrs|hour|hours)       secs=$(( num * 3600 )) ;;
+      d|day|days)                secs=$(( num * 86400 )) ;;
+      *) echo "bee log: bad unit '$unit'" >&2; exit 2 ;;
+    esac
+    since_epoch=$(( $(date -u +%s) - secs ))
+  fi
+
+  # Normalize target filter (strip leading #)
+  target_filter="${target_filter#\#}"
+
+  local target_arg="${target_filter:-}"
+  local agent_arg="${agent_filter:-}"
+
+  local filtered
+  filtered=$(jq -c --argjson since "$since_epoch" \
+                    --arg agent "$agent_arg" \
+                    --arg target "$target_arg" '
+    select(
+      (($agent == "") or (.agent == $agent))
+      and (($target == "") or (.target == ("#" + $target)))
+      and (($since == 0) or ((.ts | sub("Z$"; "Z") | fromdateiso8601) >= $since))
+    )
+  ' "$activity_log" 2>/dev/null | tail -n "$limit")
+
+  if (( raw )); then
+    printf '%s\n' "$filtered"
+    return
+  fi
+
+  if [[ -z "$filtered" ]]; then
+    echo "(no matching events)"
+    return
+  fi
+
+  # Pretty-print. Columns: time | agent | target | outcome/state | title.
+  printf '%s\n' "$filtered" | jq -r '
+    [
+      (.ts | sub("\\.[0-9]+Z$"; "Z") | sub("^\\d{4}-\\d{2}-\\d{2}T"; "") | sub("Z$"; "")),
+      .agent,
+      .target,
+      (if .event == "start" then "started"
+       else
+         (if .outcome != null then .outcome
+          elif .exit_code == 0 then "done"
+          else "exit:" + (.exit_code | tostring) end)
+       end),
+      (.duration_s // 0 | tostring) + "s",
+      (.title // ""),
+      (.umbrella // "")
+    ] | @tsv
+  ' | awk -F'\t' '
+    {
+      ts=$1; agent=$2; target=$3; state=$4; dur=$5; title=$6; umbrella=$7
+      # Truncate title to fit
+      if (length(title) > 50) title = substr(title, 1, 47) "..."
+      umb_str = (umbrella != "" ? "  (umbrella " umbrella ")" : "")
+      printf "%s  %-16s %-6s  %-18s  %6s  %s%s\n", ts, agent, target, state, dur, title, umb_str
+    }
+  '
+}
+
 main() {
   local cmd="${1:-help}"
   shift || true
   case "$cmd" in
     status)       cmd_status "$@" ;;
+    log)          cmd_log "$@" ;;
     pause)        cmd_pause "$@" ;;
     config)       cmd_config "$@" ;;
     watch)        cmd_watch "$@" ;;

--- a/scripts/dash.sh
+++ b/scripts/dash.sh
@@ -45,6 +45,7 @@ esac
 REPO="serenakeyitan/git-bee"
 BEE="$(cd "$(dirname "$0")" && pwd)/bee"
 TICK_LOG="$HOME/.git-bee/tick.log"
+ACTIVITY_LOG="$HOME/.git-bee/activity.ndjson"
 ROLLBACK_MARKER="$HOME/.git-bee/ROLLBACK"
 
 # ANSI
@@ -116,9 +117,35 @@ render() {
   printf '%s tick.log:%s %s%s%s\n' "$CYAN" "$RESET" "$DIM" "$last_line" "$RESET"
 
   hline
-  printf '%s Recent dispatches (last 8)%s\n' "$BOLD" "$RESET"
-  if [[ -f "$TICK_LOG" ]]; then
-    # Use a temporary variable to capture the read, avoiding partial line issues
+  printf '%s Recent activity (last 8)%s\n' "$BOLD" "$RESET"
+  if [[ -f "$ACTIVITY_LOG" ]]; then
+    # Prefer the structured activity log: it has time + agent + target +
+    # outcome (verdict scraped from the agent's comment).
+    tail -8 "$ACTIVITY_LOG" | jq -r '
+      [
+        (.ts | sub("\\.[0-9]+Z$"; "Z") | sub("^\\d{4}-\\d{2}-\\d{2}T"; "") | sub("Z$"; "")),
+        .agent,
+        .target,
+        (if .event == "start" then "started"
+         else
+           (if .outcome != null then .outcome
+            elif .exit_code == 0 then "done"
+            else "exit:" + (.exit_code | tostring) end)
+         end),
+        ((.duration_s // 0 | tostring) + "s")
+      ] | @tsv' 2>/dev/null | \
+      awk -F'\t' -v G="$GREEN" -v R="$RED" -v Y="$YELLOW" -v D="$DIM" -v B="$BOLD" -v Z="$RESET" '
+        {
+          ts=$1; agent=$2; target=$3; state=$4; dur=$5
+          color=Y
+          if (state == "started") color=D
+          else if (state == "done" || state == "pass" || state == "approved" || state == "merged") color=G
+          else if (state ~ /^exit:/ || state == "requested-changes" || state == "lazy-run" || state == "code-bug" || state == "test-bug") color=R
+          printf "  %s%s%s  %s%-10s%s %s%-5s%s  %s%-18s%s  %s%s%s\n", \
+            D, ts, Z, B, agent, Z, B, target, Z, color, state, Z, D, dur, Z
+        }'
+  elif [[ -f "$TICK_LOG" ]]; then
+    # Fallback: grep tick.log (no outcome info, just events)
     local dispatches
     if dispatches=$(grep -E 'dispatch: kind=|agent exited' "$TICK_LOG" 2>/dev/null | tail -8); then
       echo "$dispatches" | \
@@ -127,11 +154,9 @@ render() {
         sed -E "s/(agent exited non-zero \([0-9]+\))/${RED}\1${RESET}/" | \
         sed -E "s/(agent exited cleanly)/${GREEN}\1${RESET}/" | \
         sed 's/^/  /'
-    else
-      printf '  %s(could not read tick.log)%s\n' "$DIM" "$RESET"
     fi
   else
-    printf '  %s(no tick.log yet)%s\n' "$DIM" "$RESET"
+    printf '  %s(no activity yet)%s\n' "$DIM" "$RESET"
   fi
 
   hline

--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -394,6 +394,7 @@ fi
 kind="${target%% *}"
 number="${target##* }"
 log "dispatch: kind=$kind target=#$number"
+DISPATCH_START_TS=$SECONDS
 
 # Acquire claim BEFORE spawning, so concurrent ticks don't dispatch twice
 agent_id="${kind}-$(hostname -s)"
@@ -447,10 +448,13 @@ PROMPT_EOF
 )
 
 log "spawning ${CLAUDE_BIN} for role=${kind} target=#${number}"
+"$REPO_ROOT/scripts/activity.sh" start "$REPO" "$kind" "$number" "$agent_id" 2>/dev/null || true
 "$CLAUDE_BIN" -p "$prompt" --permission-mode bypassPermissions 2>&1 | tee -a "$LOG" || {
   exit_code=$?
   log "agent exited non-zero (${exit_code}) for #${number}"
+  "$REPO_ROOT/scripts/activity.sh" end "$REPO" "$kind" "$number" "$agent_id" "$exit_code" "$(( SECONDS - DISPATCH_START_TS ))" 2>/dev/null || true
   exit "$exit_code"
 }
 
 log "agent exited cleanly for #${number}"
+"$REPO_ROOT/scripts/activity.sh" end "$REPO" "$kind" "$number" "$agent_id" 0 "$(( SECONDS - DISPATCH_START_TS ))" 2>/dev/null || true


### PR DESCRIPTION
**drafter:**

Fixes #563.

## Summary
Writes NDJSON per-dispatch events to `~/.git-bee/activity.ndjson` with **time, agent, repo, target, title, umbrella, duration, and outcome** (scraped from the agent's verdict comment). `bee log` pretty-prints it.

## Demo
```
$ bee log -n 4
05:18:22  reviewer   #561   approved      60s  feat(dash): terminal dashboard...  (umbrella #560)
05:18:24  merger     #561   merged        60s  feat(dash): terminal dashboard...  (umbrella #560)
05:18:26  drafter    #561   done          60s  feat(dash): terminal dashboard...  (umbrella #560)
05:18:28  e2e        #561   pass          60s  feat(dash): terminal dashboard...  (umbrella #560)

$ bee log --agent reviewer --since 2h
$ bee log --target 554 -n 10
$ bee log --raw | jq .
```

## Outcome scraping
The hard part. The scraper looks at three sources and picks the newest match per agent:
1. **PR reviews** (from `gh pr review` — format `**reviewer verdict: approved**`)
2. **Issue/PR comments** (format `**<agent>: <outcome>**` — used by merger, drafter, auditor, e2e-supervisor)
3. **E2E trace comments** (format `**E2E trace (pass)**` — e2e agent writes verdict here, not in a self-prefixed comment)

Bodies that are just `**drafter:**` (no outcome token) are skipped so we don't return empty.

## Wiring
- `tick.sh` calls `activity.sh start` at spawn, `activity.sh end` on both exit paths.
- Both calls are `|| true`-guarded so activity-log failures can never take down a tick.
- `dash.sh` reads the NDJSON and shows outcomes in the "Recent activity" strip; falls back to tick.log grep if the file doesn't exist yet.

## Scope
Multi-repo-ready (`repo` is a field); single-repo wiring (tick.sh passes its `$REPO`). Adding a second repo later is just a config change.

## Test plan
- [x] `activity.sh start/end` for reviewer, merger, drafter, e2e on a merged PR — correctly scrapes `approved`, `merged`, `done`, `pass`.
- [x] `bee log --agent / --target / --since` all filter correctly.
- [x] `bash -n` passes on all 4 modified/new scripts.
- [x] Dashboard reads activity.ndjson and shows outcomes.
- [ ] First live dispatch after merge writes an event — observe post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)