### PR TITLE
feat(agents): align labeling with breeze 4-state convention (no source/priority)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 *.log
 .env
 .env.local
+.claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# Git-bee Agent Conventions
+
+## Label State Machine
+
+Git-bee uses exactly four breeze labels with strict mutual exclusion:
+- `breeze:new` — Newly created, not yet claimed
+- `breeze:wip` — Actively being worked on by an agent
+- `breeze:human` — Blocked on human intervention
+- `breeze:done` — Work completed
+
+### State Precedence
+
+When determining the effective state, precedence is:
+**done > MERGED/CLOSED > human > wip > absent**
+
+- GitHub's MERGED/CLOSED status implies `breeze:done` even without the label
+- Only one `breeze:*` label may be present at any time
+- State transitions must be atomic (remove old, add new)
+
+### Prohibited Labels
+
+Agents MUST NOT set these labels on issues or PRs:
+- `source:*` — Reserved for human use
+- `priority:*` — Reserved for human use
+
+Note: `priority:high` is still read by `tick.sh` for sort ordering (humans can apply it), but no agent sets it.
+
+### State Transition Helper
+
+All agents MUST use the provided helper for state transitions:
+
+```bash
+source /path/to/scripts/labels.sh
+set_breeze_state "repo-owner/repo-name" <number> <wip|human|done>
+```
+
+This helper atomically removes any existing `breeze:*` label before applying the new one, preserving mutual exclusion.
+
+## Agent Rules
+
+1. **Claim before work** — Set `breeze:wip` before starting any task
+2. **Release on completion** — Remove `breeze:wip` when done or handing off
+3. **Use helper for transitions** — Never manually add/remove breeze labels
+4. **Respect human labels** — Skip items with fresh `breeze:human` (< 2 hours old)
+
+## Implementation Reference
+
+- State transitions: `scripts/labels.sh:set_breeze_state()`
+- Dispatch logic: `scripts/tick.sh:pick_target()`
+- Breeze classifier: `first-tree/src/products/breeze/engine/runtime/classifier.ts`

--- a/agents/auditor.md
+++ b/agents/auditor.md
@@ -42,7 +42,7 @@ If any of those preconditions no longer hold when you start, exit with `auditor:
   - `**auditor: gaps-found**` (any 🟡/❌ — handing to human)
   - `**auditor: skipped — <reason>**` (preconditions no longer hold)
   Then a blank line, then the report.
-- **Close only on all-✅.** If every PR is ✅ or 📝-with-justification, label `breeze:done` and close the issue. Otherwise label `breeze:human` and leave it open.
+- **Close only on all-✅.** If every PR is ✅ or 📝-with-justification, close the issue (GitHub CLOSED status implies done, no label needed). Otherwise use the helper to label `breeze:human`: `source scripts/labels.sh && set_breeze_state "serenakeyitan/git-bee" <n> human` and leave it open.
 - **Never re-open a closed issue.** If you run on a closed issue, exit skipped.
 - **Do not modify the design-doc body.** You are read-only on the doc. Corrections belong in a follow-up PR.
 - **Do not approve, merge, or close PRs.** Your scope is the umbrella issue only.

--- a/agents/drafter.md
+++ b/agents/drafter.md
@@ -10,9 +10,9 @@ Given a design-doc issue, turn it into shipped code.
 2. Read the repo: README, agents/, scripts/. Understand the current state.
 3. Draft the design in an issue comment if the issue body is thin. Post it, wait for the human's `go` reply in a comment (poll on next tick — do not block).
 4. Once approved, break the work into one-PR-per-problem. Each PR links back with `Fixes #<issue>` — **EXCEPT** when the design-doc issue is a multi-PR umbrella (has a `## Milestone plan` section enumerating multiple PRs). In that case, sub-PRs must use `Refs #<issue>` instead. `Fixes #<issue>` on an umbrella causes GitHub to auto-close the umbrella when the first sub-PR merges, stranding the other planned PRs. The auditor agent is the one that closes the umbrella, not the merger.
-5. For each PR: write code, run tests locally, push, request review.
+5. For each PR: write code, run tests locally, push, request review. **You MUST set `breeze:wip` on PRs you open** using the helper: `source scripts/labels.sh && set_breeze_state "repo" <pr-number> wip`.
 6. Set `breeze:wip` on items you're actively working. Remove it when you hand off or finish.
-7. When all linked PRs are merged, label the design-doc issue `breeze:done` and close it.
+7. When all linked PRs are merged, use the helper to label the design-doc issue `breeze:done` and close it.
 
 ## Finalization gate
 
@@ -45,7 +45,7 @@ If you need human input or hit a blocker:
 
 Before touching an item:
 1. Check if `breeze:wip` is set - if it's fresh (labeled event < 2h old), another agent owns it. Skip.
-2. Otherwise: `gh issue edit <n> --add-label breeze:wip` to claim it.
+2. Otherwise: use the helper to claim it: `source scripts/labels.sh && set_breeze_state "serenakeyitan/git-bee" <n> wip`
 3. When done or handing off: remove the label with `gh issue edit <n> --remove-label breeze:wip`.
 
 ## Output

--- a/agents/e2e-supervisor.md
+++ b/agents/e2e-supervisor.md
@@ -75,7 +75,7 @@ Run-audit verdicts MUST use exactly one of these headers on the first line of yo
 - `**e2e-supervisor: code-bug**`
 - `**e2e-supervisor: test-bug**`
 - `**e2e-supervisor: design-trivial**` — posted immediately after you patch the design-doc body with `gh issue edit --body`.
-- `**e2e-supervisor: design-conflicting**` — followed by the Structured Brief template. Also apply `breeze:human` to the PR before exiting (`gh issue edit <pr> --add-label breeze:human`).
+- `**e2e-supervisor: design-conflicting**` — followed by the Structured Brief template. Also apply `breeze:human` to the PR before exiting using the helper: `source scripts/labels.sh && set_breeze_state "serenakeyitan/git-bee" <pr> human`.
 
 Plan-review mode (Phase 2) uses its own headers; the routing table above is for run-audit only.
 

--- a/scripts/labels.sh
+++ b/scripts/labels.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Label helpers for git-bee agents
+#
+# Provides atomic breeze state transitions with mutual exclusion.
+
+set -euo pipefail
+
+# set_breeze_state <repo> <number> <state>
+#
+# Atomically sets the breeze state on an issue/PR to exactly one of:
+#   wip, human, done
+#
+# This removes any existing breeze:* labels before applying the new one,
+# ensuring mutual exclusion per the Breeze convention.
+#
+# Examples:
+#   set_breeze_state "serenakeyitan/git-bee" 123 wip
+#   set_breeze_state "serenakeyitan/git-bee" 456 human
+#   set_breeze_state "serenakeyitan/git-bee" 789 done
+set_breeze_state() {
+  local repo="$1"
+  local number="$2"
+  local state="$3"
+
+  # Validate state argument
+  case "$state" in
+    wip|human|done) ;;
+    *)
+      echo "ERROR: set_breeze_state: invalid state '$state' (must be: wip, human, or done)" >&2
+      return 1
+      ;;
+  esac
+
+  # Get current labels
+  local current_labels
+  current_labels=$(gh issue view "$number" --repo "$repo" --json labels --jq '.labels[].name' 2>/dev/null || echo "")
+
+  # Remove all existing breeze:* labels
+  local breeze_labels
+  breeze_labels=$(echo "$current_labels" | grep "^breeze:" || true)
+
+  if [[ -n "$breeze_labels" ]]; then
+    while IFS= read -r label; do
+      [[ -z "$label" ]] && continue
+      gh issue edit "$number" --repo "$repo" --remove-label "$label" >/dev/null 2>&1 || true
+    done <<< "$breeze_labels"
+  fi
+
+  # Apply the new state label
+  gh issue edit "$number" --repo "$repo" --add-label "breeze:$state" >/dev/null 2>&1
+
+  echo "set_breeze_state: #$number → breeze:$state"
+}

--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -14,6 +14,8 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$HERE/.." && pwd)"
 # shellcheck disable=SC1091
 source "$HERE/claim.sh"
+# shellcheck disable=SC1091
+source "$HERE/labels.sh"
 
 REPO="serenakeyitan/git-bee"
 LOCK="/tmp/git-bee-agent.pid"
@@ -86,10 +88,13 @@ The tick loop is now paused and will not dispatch agents until the ROLLBACK mark
 EOF
 )
 
-      gh issue create --repo "$REPO" \
+      issue_num=$(gh issue create --repo "$REPO" \
         --title "Automatic rollback: 3 consecutive tick crashes detected" \
-        --body "$issue_body" \
-        --label "breeze:human,priority:high" 2>&1 | tee -a "$LOG" || true
+        --body "$issue_body" 2>&1 | tee -a "$LOG" | grep -oE '[0-9]+$' || echo "")
+
+      if [[ -n "$issue_num" ]]; then
+        set_breeze_state "$REPO" "$issue_num" "human" 2>&1 | tee -a "$LOG" || true
+      fi
     else
       log "WARNING: Could not find a known-good SHA in tick history"
     fi
@@ -232,7 +237,7 @@ pick_target() {
         design-conflicting)
           # Belt-and-suspenders: supervisor should have applied breeze:human,
           # but ensure it's labeled so this tick never re-dispatches.
-          gh issue edit "$pr_n" --repo "$REPO" --add-label "breeze:human" >/dev/null 2>&1 || true
+          set_breeze_state "$REPO" "$pr_n" "human" >/dev/null 2>&1 || true
           log "skip: #$pr_n design-conflicting — labeled breeze:human, held for human"
           ;;
         design-trivial|pass) : ;;  # handled elsewhere / nothing to do


### PR DESCRIPTION
**drafter:**

Fixes #554.

## Summary

Ports breeze's label state machine into git-bee. Agents were drifting: I filed issues with `source:notification` / `priority:high`, drafter opened PRs with no labels, and `tick.sh` auto-applied `priority:high` on crash-rollback issues. Breeze (in `first-tree/src/products/breeze`) uses exactly four labels (`breeze:new|wip|human|done`) with strict mutual exclusion — nothing else.

## Changes

- `scripts/labels.sh` — new helper `set_breeze_state <repo> <n> <wip|human|done>`. Atomically removes any prior `breeze:*` before applying the new one, preserving mutual exclusion.
- `AGENTS.md` (root) — canonical doc for the state machine. Precedence: **done > MERGED/CLOSED > human > wip > absent**. Prohibits `source:*` / `priority:*` on issues/PRs. `priority:high` is still read in `tick.sh`'s sort logic (humans can apply it), but no agent sets it.
- `scripts/tick.sh` — crash-rollback issue creation and supervisor `design-conflicting` handler both go through `set_breeze_state`. Drops auto-applied `priority:high`.
- `agents/drafter.md` — requires using the helper; drafter must set `breeze:wip` on PRs it opens (not just the parent issue).
- `agents/e2e-supervisor.md` — `design-conflicting` transition uses the helper.
- `agents/auditor.md` — close-on-all-✅ doesn't set `breeze:done` (GitHub-CLOSED derives done); gap path uses the helper for `breeze:human`.
- `.gitignore` — ignore `.claude/` worktree artifacts (linter was staging them).

## Test plan

- [x] `set_breeze_state foo 1 wrong` errors with validation.
- [ ] Next agent-opened PR should land with `breeze:wip` from the drafter claim.
- [ ] Run a full tick cycle to ensure the new helper is called correctly
- [ ] Verify no regressions in dispatch logic

---
_Posted by git-bee drafter agent._