### PR TITLE
Fix rollback guard silence when no known-good SHA exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,19 @@ To prevent label churn, `breeze:wip` is kept when agents hand off work. The next
 - [`agents/merger.md`](agents/merger.md) — Merges approved PRs with passing E2E; closes linked issues with `breeze:done`.
 - [`agents/auditor.md`](agents/auditor.md) — Fresh-context audit of multi-PR design-doc coverage. Runs when every PR in a doc's `## Milestone plan` is merged; closes the umbrella only if all coverage checks pass, else labels `breeze:human`.
 
-## Cron
+## Setup
+
+### Git hooks
+
+To prevent syntax errors from being pushed to main (issue #557), install the pre-push hook:
+
+```bash
+./scripts/install-hooks.sh
+```
+
+This validates `tick.sh` and other critical scripts before allowing pushes to main.
+
+### Cron
 
 `launchd/com.serenakeyitan.git-bee.plist` — installs `scripts/tick.sh` as a 5-minute launch agent (default). Install with:
 

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Install git hooks for the git-bee repository
+# This prevents syntax errors from being pushed to main (issue #557)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOKS_DIR="${REPO_ROOT}/.git/hooks"
+
+echo "Installing git hooks..."
+
+# Create the pre-push hook
+cat > "${HOOKS_DIR}/pre-push" <<'EOF'
+#!/usr/bin/env bash
+# Pre-push hook to validate tick.sh syntax before pushing
+# Prevents syntax errors from reaching main (issue #557)
+
+set -euo pipefail
+
+# ANSI color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+# Get the remote and branch being pushed to
+remote="$1"
+url="$2"
+
+# Check if we're pushing to main/master
+while read local_ref local_sha remote_ref remote_sha
+do
+  # Extract branch name from refs/heads/branch
+  remote_branch="${remote_ref#refs/heads/}"
+
+  # Only validate if pushing to main or master
+  if [[ "$remote_branch" == "main" || "$remote_branch" == "master" ]]; then
+    echo "Pre-push: Validating tick.sh syntax before push to $remote_branch..."
+
+    # Check if tick.sh exists
+    if [[ ! -f "scripts/tick.sh" ]]; then
+      echo -e "${RED}ERROR: scripts/tick.sh not found${NC}"
+      exit 1
+    fi
+
+    # Validate tick.sh syntax
+    if bash -n scripts/tick.sh 2>/dev/null; then
+      echo -e "${GREEN}✓ tick.sh syntax check passed${NC}"
+    else
+      echo -e "${RED}ERROR: tick.sh has syntax errors:${NC}"
+      bash -n scripts/tick.sh 2>&1 | sed 's/^/  /'
+      echo ""
+      echo -e "${RED}Push aborted. Fix the syntax errors before pushing.${NC}"
+      exit 1
+    fi
+
+    # Also validate other critical scripts if they exist
+    critical_scripts=(
+      "scripts/claim.sh"
+      "scripts/labels.sh"
+      "scripts/gate-check.sh"
+      "scripts/notification-scanner.sh"
+      "scripts/preflight-push.sh"
+      "scripts/activity.sh"
+    )
+
+    for script in "${critical_scripts[@]}"; do
+      if [[ -f "$script" ]]; then
+        if ! bash -n "$script" 2>/dev/null; then
+          echo -e "${RED}ERROR: $script has syntax errors:${NC}"
+          bash -n "$script" 2>&1 | sed 's/^/  /'
+          echo ""
+          echo -e "${RED}Push aborted. Fix the syntax errors before pushing.${NC}"
+          exit 1
+        fi
+      fi
+    done
+
+    echo -e "${GREEN}✓ All script syntax checks passed${NC}"
+  fi
+done
+
+exit 0
+EOF
+
+chmod +x "${HOOKS_DIR}/pre-push"
+
+echo "✓ Pre-push hook installed successfully"
+echo ""
+echo "The pre-push hook will validate script syntax before pushing to main/master."
+echo "This prevents syntax errors from reaching production (issue #557)."

--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -100,7 +100,45 @@ EOF
         set_breeze_state "$REPO" "$new_issue_n" human
       fi
     else
-      log "WARNING: Could not find a known-good SHA in tick history"
+      log "ERROR: Could not find a known-good SHA in tick history — filing alert issue"
+
+      # Write ROLLBACK marker to pause the loop even without a rollback target
+      cat > "$ROLLBACK_MARKER" <<EOF
+Automatic pause triggered at $(date -u +%Y-%m-%dT%H:%M:%SZ)
+Reason: 3 consecutive non-zero tick exits with no known-good SHA available
+Current SHA: $TICK_START_SHA
+Remove this file to resume normal operation.
+EOF
+
+      # Create breeze:human issue to alert the user
+      issue_body=$(cat <<EOF
+**Tick loop crashing — no rollback target available**
+
+The git-bee tick loop detected 3 consecutive crashes but could not find a known-good SHA to roll back to.
+
+- **Time**: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+- **Current SHA**: $TICK_START_SHA
+- **Tick history has no exit-0 rows**
+
+**Action required**:
+1. Investigate the crashes in \`~/.git-bee/tick.log\`
+2. Manually fix the issue or checkout a known-good commit
+3. Remove \`~/.git-bee/ROLLBACK\` to resume the tick loop
+
+The tick loop is now paused and will not dispatch agents until the ROLLBACK marker is removed.
+EOF
+)
+
+      # Create the issue and apply breeze:human via the labeling helper.
+      local new_issue_url
+      new_issue_url=$(gh issue create --repo "$REPO" \
+        --title "Tick crashing with no rollback target available" \
+        --body "$issue_body" 2>&1 | tee -a "$LOG" | tail -1 || true)
+      local new_issue_n
+      new_issue_n=$(echo "$new_issue_url" | grep -oE '/issues/[0-9]+' | grep -oE '[0-9]+' || echo "")
+      if [[ -n "$new_issue_n" ]]; then
+        set_breeze_state "$REPO" "$new_issue_n" human
+      fi
     fi
   fi
 fi


### PR DESCRIPTION
**drafter:**

Fixes #557

## Problem
The rollback guard in `tick.sh` was silently failing when tick history contained no known-good SHA (all non-zero exits). This caused a crash loop with no visible signal to the user — no issue filed, no ROLLBACK marker written, just silent continuous crashes.

## Solution
Implemented the two fixes recommended in #557:

### Fix (a): Alert on no known-good SHA
When 3 consecutive crashes are detected but no known-good SHA exists in tick history:
- Now files a `breeze:human` alert issue to notify the user
- Writes the ROLLBACK marker to pause the tick loop
- Previously just logged a warning and continued crashing silently

### Fix (c): Pre-push syntax validation
Added a pre-push hook that validates the syntax of critical scripts before allowing pushes to main:
- Checks `tick.sh` and other critical scripts with `bash -n`
- Prevents syntax errors from reaching production
- Install with `./scripts/install-hooks.sh`
- Added documentation to README

## Testing
- Verified `tick.sh` syntax is valid after modifications
- Tested the hook installation script works correctly
- The pre-push hook successfully validates script syntax

The combination of these fixes ensures:
1. We're alerted when crash loops occur (even without rollback target)
2. The most common cause of crash loops is prevented at commit time