### PR TITLE
notification scanner: add explicit exclude_repos deny-list

### DIFF
--- a/scripts/bee
+++ b/scripts/bee
@@ -51,6 +51,9 @@ Usage:
   bee watch remove <owner/repo>  Remove a repo from the watchlist
   bee watch pause        Disable scanner without losing watchlist
   bee watch resume       Re-enable scanner
+  bee exclude list       Show excluded repos (deny-list)
+  bee exclude add <owner/repo>    Add a repo to the exclude list
+  bee exclude remove <owner/repo> Remove a repo from the exclude list
 
 Exit codes:
   0  agent idle or running cleanly
@@ -627,6 +630,62 @@ cmd_watch() {
   esac
 }
 
+cmd_exclude() {
+  local action="${1:-list}"
+  shift || true
+
+  mkdir -p "$(dirname "$CONFIG_FILE")"
+  # Bootstrap config via cmd_config's default template if missing.
+  if [[ ! -f "$CONFIG_FILE" ]]; then
+    cmd_config get >/dev/null
+  fi
+
+  local repo
+  case "$action" in
+    list)
+      local count
+      count=$(jq -r '(.watch.exclude_repos // []) | length' "$CONFIG_FILE")
+      if (( count == 0 )); then
+        echo "exclude list: empty"
+        echo "  (no excluded repos — add one with: bee exclude add <owner/repo>)"
+      else
+        echo "exclude list:"
+        jq -r '.watch.exclude_repos[]' "$CONFIG_FILE" | sed 's/^/  - /'
+      fi
+      ;;
+    add)
+      repo="${1:-}"
+      if [[ -z "$repo" ]] || ! [[ "$repo" =~ ^[^/]+/[^/]+$ ]]; then
+        echo "bee exclude add: need owner/repo" >&2
+        exit 2
+      fi
+      jq --arg r "$repo" '
+        .watch //= {enabled: false, repos: []}
+        | .watch.exclude_repos //= []
+        | if (.watch.exclude_repos | index($r)) then . else .watch.exclude_repos += [$r] end
+      ' "$CONFIG_FILE" > "${CONFIG_FILE}.tmp" && mv "${CONFIG_FILE}.tmp" "$CONFIG_FILE"
+      echo "bee exclude: added ${repo} to deny-list"
+      ;;
+    remove)
+      repo="${1:-}"
+      if [[ -z "$repo" ]]; then
+        echo "bee exclude remove: need owner/repo" >&2
+        exit 2
+      fi
+      jq --arg r "$repo" '
+        .watch //= {enabled: false, repos: []}
+        | .watch.exclude_repos = ((.watch.exclude_repos // []) - [$r])
+      ' "$CONFIG_FILE" > "${CONFIG_FILE}.tmp" && mv "${CONFIG_FILE}.tmp" "$CONFIG_FILE"
+      echo "bee exclude: removed ${repo} from deny-list"
+      ;;
+    *)
+      echo "bee exclude: unknown action: $action" >&2
+      echo "usage: bee exclude add|remove|list [owner/repo]" >&2
+      exit 2
+      ;;
+  esac
+}
+
 cmd_log() {
   local activity_log="$HOME/.git-bee/activity.ndjson"
   if [[ ! -f "$activity_log" ]]; then
@@ -754,6 +813,7 @@ main() {
     pause)        cmd_pause "$@" ;;
     config)       cmd_config "$@" ;;
     watch)        cmd_watch "$@" ;;
+    exclude)      cmd_exclude "$@" ;;
     help|-h|--help) usage ;;
     *) echo "bee: unknown command: $cmd" >&2; usage >&2; exit 2 ;;
   esac

--- a/scripts/notification-scanner.sh
+++ b/scripts/notification-scanner.sh
@@ -50,6 +50,7 @@ _migrate_if_legacy() {
           watch: {
             enabled: (($in.scope // "exclusion") == "curated" and (($in.include_repos // []) | length) > 0),
             repos: ($in.include_repos // []),
+            exclude_repos: ($in.exclude_repos // []),
             classify_as_needs_fix: ["review_requested", "assign", "mention", "team_mention"],
             per_repo_ceiling: 5,
             global_ceiling: 20
@@ -63,12 +64,14 @@ _migrate_if_legacy
 if [[ -f "$CONFIG_FILE" ]]; then
     WATCH_ENABLED=$(jq -r '.watch.enabled // false' "$CONFIG_FILE")
     WATCH_REPOS=$(jq -r '(.watch.repos // [])[]' "$CONFIG_FILE" 2>/dev/null || true)
+    EXCLUDE_REPOS=$(jq -r '(.watch.exclude_repos // [])[]' "$CONFIG_FILE" 2>/dev/null || true)
     NEEDS_FIX_REASONS=$(jq -r '(.watch.classify_as_needs_fix // ["review_requested","assign","mention","team_mention"])[]' "$CONFIG_FILE" 2>/dev/null)
     PER_REPO_CEILING=$(jq -r '.watch.per_repo_ceiling // 5' "$CONFIG_FILE")
     GLOBAL_CEILING=$(jq -r '.watch.global_ceiling // 20' "$CONFIG_FILE")
 else
     WATCH_ENABLED="false"
     WATCH_REPOS=""
+    EXCLUDE_REPOS=""
     NEEDS_FIX_REASONS="review_requested
 assign
 mention
@@ -99,6 +102,15 @@ is_watched() {
         [[ -z "$w" ]] && continue
         [[ "$repo" == "$w" ]] && return 0
     done <<< "$WATCH_REPOS"
+    return 1
+}
+
+is_excluded() {
+    local repo="$1"
+    while IFS= read -r e; do
+        [[ -z "$e" ]] && continue
+        [[ "$repo" == "$e" ]] && return 0
+    done <<< "$EXCLUDE_REPOS"
     return 1
 }
 
@@ -201,6 +213,7 @@ ${r}	${c}"
         [[ -n "$subject_url" ]] && number=$(echo "$subject_url" | grep -oE '[0-9]+$' || echo "")
 
         is_watched "$repo" || continue
+        is_excluded "$repo" && continue
         is_needs_fix "$reason" || continue
         [[ -z "$number" ]] && continue
 


### PR DESCRIPTION
**drafter:**

## Summary
This PR adds an explicit exclude_repos deny-list to the notification scanner as a second layer of defense against unwanted notifications. Even if a repo is accidentally added to the watch list, repos in the exclude_repos list will be skipped.

## Changes Made
- `scripts/notification-scanner.sh`: 
  - Load `exclude_repos` from config
  - Add `is_excluded()` helper function
  - Check exclusion after `is_watched()` to drop notifications from excluded repos
  - Migrate legacy configs to preserve `exclude_repos` if present

- `scripts/bee`:
  - Add new `exclude` command with `add`, `remove`, and `list` subcommands  
  - Commands mirror the `watch` interface for consistency
  - Update usage documentation

## Test Plan
- [x] Added a repo to both watch list and exclude list - verified scanner skips it
- [x] Added a repo to only exclude list - verified no effect (as expected)
- [x] Tested `bee exclude add/remove/list` commands - all work correctly
- [x] Verified config.json structure is preserved with new `watch.exclude_repos` array
- [x] Tested legacy migration preserves exclude_repos if present

Fixes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)