### PR TITLE
tick: optional tmux UI mode — spawn each agent in its own attachable window

### DIFF
--- a/scripts/bee
+++ b/scripts/bee
@@ -54,6 +54,7 @@ Usage:
   bee exclude list       Show excluded repos (deny-list)
   bee exclude add <owner/repo>    Add a repo to the exclude list
   bee exclude remove <owner/repo> Remove a repo from the exclude list
+  bee watch-agents       Attach to tmux session to watch agents in real-time
 
 Exit codes:
   0  agent idle or running cleanly
@@ -686,6 +687,39 @@ cmd_exclude() {
   esac
 }
 
+cmd_watch_agents() {
+  # Check if tmux is available
+  if ! command -v tmux >/dev/null 2>&1; then
+    echo "bee watch-agents: tmux is not installed" >&2
+    echo "Install tmux to use the watch-agents feature" >&2
+    exit 2
+  fi
+
+  # Create session if it doesn't exist
+  if ! tmux has-session -t git-bee 2>/dev/null; then
+    echo "Creating git-bee tmux session..."
+    tmux new-session -d -s git-bee -n "waiting" "echo 'Waiting for agents to be dispatched...'; echo 'Press Ctrl-b d to detach'; cat"
+    # Set remain-on-exit for the session so completed agents stay visible
+    tmux set-option -t git-bee remain-on-exit on
+  fi
+
+  # Attach to the session
+  echo "Attaching to git-bee tmux session..."
+  echo "Navigation:"
+  echo "  Ctrl-b n    = next window"
+  echo "  Ctrl-b p    = previous window"
+  echo "  Ctrl-b w    = window list"
+  echo "  Ctrl-b d    = detach from session"
+  echo ""
+
+  # If already inside tmux, use switch-client; otherwise attach
+  if [[ -n "${TMUX:-}" ]]; then
+    tmux switch-client -t git-bee
+  else
+    tmux attach-session -t git-bee
+  fi
+}
+
 cmd_log() {
   local activity_log="$HOME/.git-bee/activity.ndjson"
   if [[ ! -f "$activity_log" ]]; then
@@ -814,6 +848,7 @@ main() {
     config)       cmd_config "$@" ;;
     watch)        cmd_watch "$@" ;;
     exclude)      cmd_exclude "$@" ;;
+    watch-agents) cmd_watch_agents "$@" ;;
     help|-h|--help) usage ;;
     *) echo "bee: unknown command: $cmd" >&2; usage >&2; exit 2 ;;
   esac

--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -665,13 +665,38 @@ notify() {
 
 log "spawning ${CLAUDE_BIN} for role=${kind} target=#${number}"
 "$REPO_ROOT/scripts/activity.sh" start "$REPO" "$kind" "$number" "$agent_id" 2>/dev/null || true
-"$CLAUDE_BIN" -p "$prompt" --permission-mode bypassPermissions 2>&1 | tee -a "$LOG" || {
-  exit_code=$?
-  log "agent exited non-zero (${exit_code}) for #${number}"
-  "$REPO_ROOT/scripts/activity.sh" end "$REPO" "$kind" "$number" "$agent_id" "$exit_code" "$(( SECONDS - DISPATCH_START_TS ))" 2>/dev/null || true
-  notify "🐝 ${kind} failed" "#${number} exited ${exit_code} after $(( (SECONDS - DISPATCH_START_TS) / 60 ))m$(( (SECONDS - DISPATCH_START_TS) % 60 ))s"
-  exit "$exit_code"
-}
+
+# Check for tmux UI mode
+if [[ "${GIT_BEE_UI:-}" == "tmux" ]] && command -v tmux >/dev/null 2>&1 && tmux has-session -t git-bee 2>/dev/null; then
+  # Dispatch to tmux window in existing git-bee session
+  log "dispatching ${kind} to tmux window '${kind}-#${number}'"
+
+  # Write prompt to temp file to avoid shell escaping issues
+  local prompt_file="/tmp/git-bee-prompt-${kind}-${number}.txt"
+  echo "$prompt" > "$prompt_file"
+
+  # Create new window and run claude with the prompt file
+  tmux new-window -t git-bee: -n "${kind}-#${number}" \
+    "cd '$REPO_ROOT' && '$CLAUDE_BIN' -p \"\$(cat '$prompt_file')\" --permission-mode bypassPermissions 2>&1 | tee -a '$LOG'; exit_code=\$?; rm -f '$prompt_file'; echo ''; echo \"Agent exited with code \$exit_code\"; '$REPO_ROOT/scripts/activity.sh' end '$REPO' '$kind' '$number' '$agent_id' \$exit_code \$(( SECONDS - $DISPATCH_START_TS )) 2>/dev/null || true; sleep 10; exit \$exit_code"
+
+  # Run janitor to clean up old windows
+  if [[ -x "$HERE/tmux-janitor.sh" ]]; then
+    "$HERE/tmux-janitor.sh" 2>/dev/null || true
+  fi
+
+  # Wait briefly to confirm dispatch succeeded
+  sleep 1
+  log "dispatched ${kind} in tmux window '${kind}-#${number}'"
+else
+  # Original headless mode
+  "$CLAUDE_BIN" -p "$prompt" --permission-mode bypassPermissions 2>&1 | tee -a "$LOG" || {
+    exit_code=$?
+    log "agent exited non-zero (${exit_code}) for #${number}"
+    "$REPO_ROOT/scripts/activity.sh" end "$REPO" "$kind" "$number" "$agent_id" "$exit_code" "$(( SECONDS - DISPATCH_START_TS ))" 2>/dev/null || true
+    notify "🐝 ${kind} failed" "#${number} exited ${exit_code} after $(( (SECONDS - DISPATCH_START_TS) / 60 ))m$(( (SECONDS - DISPATCH_START_TS) % 60 ))s"
+    exit "$exit_code"
+  }
+fi
 
 log "agent exited cleanly for #${number}"
 "$REPO_ROOT/scripts/activity.sh" end "$REPO" "$kind" "$number" "$agent_id" 0 "$(( SECONDS - DISPATCH_START_TS ))" 2>/dev/null || true

--- a/scripts/tmux-janitor.sh
+++ b/scripts/tmux-janitor.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# tmux-janitor.sh — clean up old tmux windows from finished agents
+#
+# Kills tmux windows in the git-bee session that are older than a configurable
+# TTL (default 30 minutes). Respects remain-on-exit windows that have finished.
+#
+# Called from tick.sh after each dispatch in tmux UI mode.
+
+set -euo pipefail
+
+# Configuration
+SESSION_NAME="git-bee"
+TTL_MINUTES="${GIT_BEE_TMUX_TTL:-30}"  # Default 30 minutes
+
+# Check if tmux is available and session exists
+if ! command -v tmux >/dev/null 2>&1 || ! tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+  exit 0
+fi
+
+# Get current timestamp
+NOW=$(date +%s)
+CUTOFF=$((NOW - TTL_MINUTES * 60))
+
+# List all windows in the session with their info
+# Format: window_index:window_name:pane_pid:pane_dead
+tmux list-windows -t "$SESSION_NAME" -F '#{window_index}:#{window_name}:#{pane_pid}:#{pane_dead}' 2>/dev/null | while IFS=':' read -r idx name pid dead; do
+  # Skip the "waiting" window (always keep at least one window)
+  [[ "$name" == "waiting" ]] && continue
+
+  # Only process dead panes (remain-on-exit windows where process has finished)
+  [[ "$dead" != "1" ]] && continue
+
+  # Try to determine when the window was created/finished
+  # Use the process start time as a proxy (this is best-effort)
+  if [[ -n "$pid" ]] && [[ "$pid" != "0" ]]; then
+    # On macOS, use ps with specific format
+    # On Linux, would use stat /proc/$pid or ps with different options
+    if [[ "$(uname)" == "Darwin" ]]; then
+      # Get process start time in seconds since epoch (macOS ps doesn't have lstart in epoch)
+      # Fall back to checking if process still exists
+      if ! kill -0 "$pid" 2>/dev/null; then
+        # Process is dead, but we can't easily get its end time
+        # Use window activity time if available
+        activity=$(tmux display-message -t "$SESSION_NAME:$idx" -p '#{window_activity}' 2>/dev/null || echo "0")
+
+        if [[ "$activity" != "0" ]] && [[ "$activity" -lt "$CUTOFF" ]]; then
+          echo "Killing old window: $name (index=$idx, inactive since $(date -r "$activity" '+%Y-%m-%d %H:%M:%S'))"
+          tmux kill-window -t "$SESSION_NAME:$idx" 2>/dev/null || true
+        fi
+      fi
+    else
+      # Linux: could check /proc/$pid/stat if it exists
+      # For now, just check window activity like macOS
+      activity=$(tmux display-message -t "$SESSION_NAME:$idx" -p '#{window_activity}' 2>/dev/null || echo "0")
+
+      if [[ "$activity" != "0" ]] && [[ "$activity" -lt "$CUTOFF" ]]; then
+        echo "Killing old window: $name (index=$idx, inactive since $(date -d "@$activity" '+%Y-%m-%d %H:%M:%S'))"
+        tmux kill-window -t "$SESSION_NAME:$idx" 2>/dev/null || true
+      fi
+    fi
+  fi
+done
+
+# If all windows were killed except "waiting", ensure at least one window remains
+WINDOW_COUNT=$(tmux list-windows -t "$SESSION_NAME" 2>/dev/null | wc -l | xargs)
+if [[ "$WINDOW_COUNT" == "0" ]]; then
+  # Session needs at least one window
+  tmux new-window -t "$SESSION_NAME" -n "waiting" "echo 'Waiting for agents...'; cat" 2>/dev/null || true
+fi


### PR DESCRIPTION
**drafter:**

## Summary

Implements optional tmux UI mode that spawns each dispatched agent in its own attachable tmux window, providing full visibility into agent reasoning, tool calls, and intermediate output in real-time.

## Changes

- Modified `tick.sh` to check for `GIT_BEE_UI=tmux` environment variable and dispatch to tmux windows when enabled
- Added `bee watch-agents` subcommand to create/attach to the git-bee tmux session  
- Created `tmux-janitor.sh` to automatically clean up old windows after configurable TTL (default 30 minutes)
- Default behavior remains unchanged — headless mode continues to work as before

## Implementation Details

### Mode Switching
- **Default (headless):** No change. `claude -p` as today. Everything in current pipeline stays identical.
- **Rich (tmux):** When `GIT_BEE_UI=tmux` is set in the launchd plist environment, tick.sh dispatches each agent into a tmux window inside a git-bee session instead of a headless subprocess.

### User Flow
```bash
$ bee watch-agents          # ensures git-bee session exists, attaches
# user sees: one window per live agent, named '<role>-#<n>'
# Ctrl-b n / p to flip through them, full Claude Code UI in each
# finished agents stay around (remain-on-exit on) until janitor reaps them
```

### Components
1. **tick.sh** — Branches at the dispatch site to check for tmux UI mode
2. **bee watch-agents** — Creates detached git-bee tmux session if missing, attaches the caller
3. **tmux-janitor.sh** — Reaps windows older than TTL (default 30 min) to prevent window accumulation

## Testing

- [x] Syntax validation passes for all modified scripts
- [x] tmux session creation works correctly
- [x] Default headless mode unchanged when GIT_BEE_UI is unset

Fixes #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>