### PR TITLE
latency: agents self-trigger next tick on exit

### DIFF
--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -6,7 +6,7 @@
 #   2. GitHub state — find the oldest open issue/PR without a fresh breeze:wip.
 #   3. If no unclaimed open items exist, project is finalized. Exit quietly.
 #
-# Invoked by launchd every 15 minutes.
+# Invoked by launchd every 5 minutes (StartInterval=300).
 
 set -euo pipefail
 
@@ -677,7 +677,7 @@ if [[ "${GIT_BEE_UI:-}" == "tmux" ]] && command -v tmux >/dev/null 2>&1 && tmux 
 
   # Create new window and run claude with the prompt file
   tmux new-window -t git-bee: -n "${kind}-#${number}" \
-    "cd '$REPO_ROOT' && '$CLAUDE_BIN' -p \"\$(cat '$prompt_file')\" --permission-mode bypassPermissions 2>&1 | tee -a '$LOG'; exit_code=\$?; rm -f '$prompt_file'; echo ''; echo \"Agent exited with code \$exit_code\"; '$REPO_ROOT/scripts/activity.sh' end '$REPO' '$kind' '$number' '$agent_id' \$exit_code \$(( SECONDS - $DISPATCH_START_TS )) 2>/dev/null || true; sleep 10; exit \$exit_code"
+    "cd '$REPO_ROOT' && '$CLAUDE_BIN' -p \"\$(cat '$prompt_file')\" --permission-mode bypassPermissions 2>&1 | tee -a '$LOG'; exit_code=\$?; rm -f '$prompt_file'; echo ''; echo \"Agent exited with code \$exit_code\"; '$REPO_ROOT/scripts/activity.sh' end '$REPO' '$kind' '$number' '$agent_id' \$exit_code \$(( SECONDS - $DISPATCH_START_TS )) 2>/dev/null || true; sleep 10; exec '$HERE/tick.sh'"
 
   # Run janitor to clean up old windows
   if [[ -x "$HERE/tmux-janitor.sh" ]]; then
@@ -694,10 +694,14 @@ else
     log "agent exited non-zero (${exit_code}) for #${number}"
     "$REPO_ROOT/scripts/activity.sh" end "$REPO" "$kind" "$number" "$agent_id" "$exit_code" "$(( SECONDS - DISPATCH_START_TS ))" 2>/dev/null || true
     notify "🐝 ${kind} failed" "#${number} exited ${exit_code} after $(( (SECONDS - DISPATCH_START_TS) / 60 ))m$(( (SECONDS - DISPATCH_START_TS) % 60 ))s"
-    exit "$exit_code"
+    # Self-trigger next tick for event-driven dispatch
+    exec "$HERE/tick.sh"
   }
 fi
 
 log "agent exited cleanly for #${number}"
 "$REPO_ROOT/scripts/activity.sh" end "$REPO" "$kind" "$number" "$agent_id" 0 "$(( SECONDS - DISPATCH_START_TS ))" 2>/dev/null || true
 notify "🐝 ${kind} done" "#${number} finished in $(( (SECONDS - DISPATCH_START_TS) / 60 ))m$(( (SECONDS - DISPATCH_START_TS) % 60 ))s"
+
+# Self-trigger next tick for event-driven dispatch
+exec "$HERE/tick.sh"


### PR DESCRIPTION
**drafter:**

Fixes #725

## Summary

Implement event-driven dispatch where agents trigger the next tick immediately after completion, reducing latency from up to 5 minutes (launchd interval) to near-zero.

## Changes

- Add self-triggering via `exec` after agent completion (both success and failure cases)
- Handle both headless and tmux UI modes appropriately
- Fix documentation comment (was "15 minutes", now correctly "5 minutes (StartInterval=300)")
- Use `exec` to replace the current process, avoiding a recursive call stack
- PID lock at `/tmp/git-bee-agent.pid` ensures at-most-one concurrent agent, making self-triggering safe

## How it works

1. When an agent completes (either successfully or with failure), it calls `exec "$HERE/tick.sh"` 
2. This replaces the current process with a new tick.sh invocation
3. The PID lock prevents concurrent agents, so the new tick either finds work or exits cleanly
4. The 5-minute launchd interval remains as a safety net for agents that die without running their exit hook

## Expected effect

Near-zero latency between agent-done and next-agent-start. Previously, users had to wait up to 5 minutes for the next launchd trigger. Now the next agent starts immediately after the previous one finishes.

## Testing

- Syntax verified with `bash -n`
- Self-triggering uses `exec` to avoid process accumulation
- Both tmux and headless modes handled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>