### PR TITLE
escape hatch: check comments too, not just review bodies (follow-up to #740)

### DIFF
--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -239,6 +239,7 @@ pick_target() {
     | select(
         .reviewDecision == "APPROVED"
         or any(.reviews[]?.body // ""; contains("<!-- bee:approved-for-e2e -->"))
+        or any(.comments[]?.body // ""; contains("<!-- bee:approved-for-e2e -->"))
       )
     | select(any(.comments[]?.body // ""; contains("**E2E trace (pass)**")))
     | .number
@@ -313,6 +314,7 @@ pick_target() {
     | select(
         .reviewDecision == "APPROVED"
         or any(.reviews[]?.body // ""; contains("<!-- bee:approved-for-e2e -->"))
+        or any(.comments[]?.body // ""; contains("<!-- bee:approved-for-e2e -->"))
       )
     | select(any(.comments[]?.body // ""; contains("**E2E trace")) | not)
     | .number


### PR DESCRIPTION
**drafter:**

## Summary

This PR fixes the escape hatch behavior introduced in #740. The `<!-- bee:approved-for-e2e -->` marker was only being checked in review bodies but not in PR comments. This caused self-authored PRs to get stuck in the pipeline when humans approved them via comments (the natural workflow since you can't formally approve your own PRs).

## Changes

Added comment body checks alongside the existing review body checks in `scripts/tick.sh`:
- Line 242: e2e-dispatch filter for mergeable PRs - added `or any(.comments[]?.body // ""; contains("<!-- bee:approved-for-e2e -->"))`
- Line 317: approved-PRs filter for e2e dispatch - added the same check

Note: The drafter-revise guard (lines 362-363) already checks both reviews and comments, so no change was needed there despite the issue mentioning line 419.

## Testing

- Syntax validated with `bash -n scripts/tick.sh`
- The jq filters follow the same pattern as the existing comment checks for E2E traces

Fixes #742