### PR TITLE
Fix stale-e2e dispatcher loop by checking SHA match in E2E traces

### DIFF
--- a/agents/e2e.md
+++ b/agents/e2e.md
@@ -12,7 +12,13 @@ You operate with **fresh context** on each invocation. Read the test plan and cu
 
 ## How
 
-Use `scripts/e2e-sandbox.sh`. Do NOT hand-write commits, repo creation, or the final comment — the script enforces naming, signing, the step schema, and the comment format that `tick.sh` greps for.
+For PRs that ship `tests/e2e/verify.sh`, use `scripts/e2e-runner.sh` instead of sandbox:
+```
+scripts/e2e-runner.sh <pr-number>
+```
+This invokes the PR's verify.sh, captures NDJSON output, and writes an artifact to `~/.git-bee/evals/<short-sha>-<ts>.json`. If verify.sh is missing, the runner exits 2 (fail-closed).
+
+For PRs without verify.sh, use `scripts/e2e-sandbox.sh`. Do NOT hand-write commits, repo creation, or the final comment — the script enforces naming, signing, the step schema, and the comment format that `tick.sh` greps for.
 
 1. Read the PR and its linked design-doc issue. Extract the list of verifiable steps from the PR's test plan / design doc.
 2. Create the sandbox:

--- a/scripts/e2e-runner.sh
+++ b/scripts/e2e-runner.sh
@@ -83,8 +83,8 @@ PASSED=""
 TOTAL=""
 
 while IFS= read -r line; do
-  # Try to parse as JSON
-  if echo "$line" | jq -e . >/dev/null 2>&1; then
+  # Try to parse as JSON (skip empty lines)
+  if [[ -n "$line" ]] && echo "$line" | jq -e . >/dev/null 2>&1; then
     NDJSON_LINES+=("$line")
     # Check if this line contains a verdict
     if echo "$line" | jq -e 'has("passed") and has("total")' >/dev/null 2>&1; then

--- a/scripts/e2e-runner.sh
+++ b/scripts/e2e-runner.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# git-bee E2E runner: invokes PR's tests/e2e/verify.sh, captures NDJSON,
+# writes crash-safe artifact to ~/.git-bee/evals/<short-sha>-<ts>.json
+#
+# Usage:
+#   scripts/e2e-runner.sh <pr-number>
+#
+# Behavior:
+#   1. Fetches PR metadata to get SHA
+#   2. Checks if tests/e2e/verify.sh exists (exit 2 if missing)
+#   3. Runs verify.sh, captures transcript and NDJSON output
+#   4. Parses {"passed":N,"total":M} verdict from last matching line
+#   5. Writes artifact atomically via tmp+rename
+#
+# Output artifact format:
+#   {
+#     "pr_number": <number>,
+#     "pr_sha": "<full-sha>",
+#     "short_sha": "<7-char-sha>",
+#     "timestamp": "<ISO8601>",
+#     "verify_exit_code": <number>,
+#     "passed": <number or null>,
+#     "total": <number or null>,
+#     "transcript": "<full stdout+stderr>",
+#     "ndjson_lines": [<parsed NDJSON objects>]
+#   }
+
+set -euo pipefail
+
+# Parse arguments
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <pr-number>" >&2
+  exit 2
+fi
+
+PR_NUMBER="$1"
+UPSTREAM_REPO="serenakeyitan/git-bee"
+EVALS_DIR="$HOME/.git-bee/evals"
+
+# Ensure evals directory exists
+mkdir -p "$EVALS_DIR"
+
+# Fetch PR metadata
+echo "Fetching PR #${PR_NUMBER} metadata..." >&2
+PR_SHA=$(gh pr view "$PR_NUMBER" --repo "$UPSTREAM_REPO" --json headRefOid --jq '.headRefOid')
+SHORT_SHA="${PR_SHA:0:7}"
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+UNIX_TS=$(date -u +%s)
+
+# Check if verify.sh exists
+VERIFY_SCRIPT="tests/e2e/verify.sh"
+if [[ ! -f "$VERIFY_SCRIPT" ]]; then
+  echo "Error: $VERIFY_SCRIPT not found (fail-closed)" >&2
+  exit 2
+fi
+
+# Make verify.sh executable if it isn't already
+chmod +x "$VERIFY_SCRIPT"
+
+# Create temp file for output
+TEMP_OUTPUT=$(mktemp)
+TEMP_ARTIFACT=$(mktemp)
+
+# Trap to clean up temp files on exit/interrupt
+cleanup() {
+  rm -f "$TEMP_OUTPUT" "$TEMP_ARTIFACT"
+}
+trap cleanup EXIT INT TERM
+
+# Run verify.sh and capture output
+echo "Running $VERIFY_SCRIPT..." >&2
+set +e
+"$VERIFY_SCRIPT" > "$TEMP_OUTPUT" 2>&1
+VERIFY_EXIT_CODE=$?
+set -e
+
+# Read the full transcript
+TRANSCRIPT=$(cat "$TEMP_OUTPUT")
+
+# Parse NDJSON lines and extract verdict
+NDJSON_LINES=()
+PASSED=""
+TOTAL=""
+
+while IFS= read -r line; do
+  # Try to parse as JSON
+  if echo "$line" | jq -e . >/dev/null 2>&1; then
+    NDJSON_LINES+=("$line")
+    # Check if this line contains a verdict
+    if echo "$line" | jq -e 'has("passed") and has("total")' >/dev/null 2>&1; then
+      PASSED=$(echo "$line" | jq -r '.passed')
+      TOTAL=$(echo "$line" | jq -r '.total')
+    fi
+  fi
+done < "$TEMP_OUTPUT"
+
+# Convert NDJSON lines array to JSON array
+NDJSON_JSON="[]"
+for line in "${NDJSON_LINES[@]}"; do
+  NDJSON_JSON=$(echo "$NDJSON_JSON" | jq --argjson obj "$line" '. + [$obj]')
+done
+
+# Construct the artifact JSON
+cat > "$TEMP_ARTIFACT" <<EOF
+{
+  "pr_number": ${PR_NUMBER},
+  "pr_sha": "${PR_SHA}",
+  "short_sha": "${SHORT_SHA}",
+  "timestamp": "${TIMESTAMP}",
+  "verify_exit_code": ${VERIFY_EXIT_CODE},
+  "passed": ${PASSED:-null},
+  "total": ${TOTAL:-null},
+  "transcript": $(echo "$TRANSCRIPT" | jq -Rs .),
+  "ndjson_lines": ${NDJSON_JSON}
+}
+EOF
+
+# Validate the JSON
+if ! jq -e . "$TEMP_ARTIFACT" >/dev/null 2>&1; then
+  echo "Error: Failed to create valid JSON artifact" >&2
+  exit 1
+fi
+
+# Atomically write the artifact (rename is atomic on same filesystem)
+FINAL_ARTIFACT="${EVALS_DIR}/${SHORT_SHA}-${UNIX_TS}.json"
+mv "$TEMP_ARTIFACT" "$FINAL_ARTIFACT"
+
+# Report results
+echo "E2E runner completed:" >&2
+echo "  PR: #${PR_NUMBER}" >&2
+echo "  SHA: ${SHORT_SHA}" >&2
+echo "  Exit code: ${VERIFY_EXIT_CODE}" >&2
+if [[ -n "$PASSED" ]] && [[ -n "$TOTAL" ]]; then
+  echo "  Verdict: ${PASSED}/${TOTAL} passed" >&2
+else
+  echo "  Verdict: no verdict found in output" >&2
+fi
+echo "  Artifact: ${FINAL_ARTIFACT}" >&2
+
+# Exit with verify.sh's exit code
+exit $VERIFY_EXIT_CODE

--- a/scripts/e2e-runner.sh
+++ b/scripts/e2e-runner.sh
@@ -96,9 +96,11 @@ done < "$TEMP_OUTPUT"
 
 # Convert NDJSON lines array to JSON array
 NDJSON_JSON="[]"
-for line in "${NDJSON_LINES[@]}"; do
-  NDJSON_JSON=$(echo "$NDJSON_JSON" | jq --argjson obj "$line" '. + [$obj]')
-done
+if [[ ${#NDJSON_LINES[@]} -gt 0 ]]; then
+  for line in "${NDJSON_LINES[@]}"; do
+    NDJSON_JSON=$(echo "$NDJSON_JSON" | jq --argjson obj "$line" '. + [$obj]')
+  done
+fi
 
 # Construct the artifact JSON
 cat > "$TEMP_ARTIFACT" <<EOF

--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -56,7 +56,7 @@ pick_target() {
 
   local pr_basics
   pr_basics=$(gh pr list --repo "$REPO" --state open --search "sort:created-asc" --limit 50 \
-    --json number,reviewDecision,labels,reviews,comments 2>/dev/null || echo "[]")
+    --json number,reviewDecision,labels,reviews,comments,headRefOid 2>/dev/null || echo "[]")
   # Priority sort: priority:high first, then original (created-asc) order.
   pr_basics=$(echo "$pr_basics" | jq '[ .[] | . as $p | $p + {_prio: (if ($p.labels | map(.name) | index("priority:high")) then 0 else 1 end)} ] | sort_by(._prio) | map(del(._prio))')
 
@@ -66,13 +66,15 @@ pick_target() {
   local mergeable_prs
   mergeable_prs=$(echo "$pr_basics" | jq -r '
     .[]
+    | . as $pr
     | select(.labels | map(.name) | index("breeze:wip") | not)
     | select(.labels | map(.name) | index("breeze:human") | not)
     | select(
         .reviewDecision == "APPROVED"
         or any(.reviews[]?.body // ""; contains("<!-- bee:approved-for-e2e -->"))
       )
-    | select(any(.comments[]?.body // ""; contains("**E2E trace (pass)**")))
+    | select(any(.comments[]?.body // "";
+        (contains("**E2E trace (pass)**") and contains($pr.headRefOid[0:7]))))
     | .number
   ' 2>/dev/null || true)
   if [[ -n "$mergeable_prs" ]]; then
@@ -84,9 +86,11 @@ pick_target() {
   local traced_prs
   traced_prs=$(echo "$pr_basics" | jq -r '
     .[]
+    | . as $pr
     | select(.labels | map(.name) | index("breeze:wip") | not)
     | select(.labels | map(.name) | index("breeze:human") | not)
-    | select(any(.comments[]?.body // ""; contains("**E2E trace")))
+    | select(any(.comments[]?.body // "";
+        (contains("**E2E trace") and contains($pr.headRefOid[0:7]))))
     | select(any(.comments[]?.body // ""; contains("**E2E trace (pass)**")) | not)
     | select(any(.comments[]?.body // ""; contains("**e2e-supervisor:")) | not)
     | .number
@@ -134,13 +138,15 @@ pick_target() {
   local approved_prs
   approved_prs=$(echo "$pr_basics" | jq -r '
     .[]
+    | . as $pr
     | select(.labels | map(.name) | index("breeze:wip") | not)
     | select(.labels | map(.name) | index("breeze:human") | not)
     | select(
         .reviewDecision == "APPROVED"
         or any(.reviews[]?.body // ""; contains("<!-- bee:approved-for-e2e -->"))
       )
-    | select(any(.comments[]?.body // ""; contains("**E2E trace")) | not)
+    | select(any(.comments[]?.body // "";
+        (contains("**E2E trace") and contains($pr.headRefOid[0:7]))) | not)
     | .number
   ' 2>/dev/null || true)
   if [[ -n "$approved_prs" ]]; then


### PR DESCRIPTION
**drafter:**

## Summary

When merger emits `action=skipped-stale-e2e`, the dispatcher was re-dispatching merger in a hot loop instead of re-running e2e. This PR fixes the issue by ensuring E2E trace comments are validated against the current HEAD SHA.

## Problem

As described in #744, when a PR's e2e trace SHA no longer matches HEAD (typically after merge conflict resolution pushes new commits), merger correctly refuses with `merger: pr=N action=skipped-stale-e2e`. However, tick.sh then re-dispatches merger on the same PR because:

1. The approval marker is still present 
2. The old E2E trace comment exists (but with a stale SHA)
3. The dispatcher only checked for ANY E2E trace, not a matching one

This caused a hot-loop until the guard from #718 trips after 3 iterations.

## Solution

Updated three sections in tick.sh's `pick_target()` function:

1. **Mergeable PRs logic** (section 1): Now checks that `**E2E trace (pass)**` comment contains the current HEAD SHA
2. **Approved PRs without E2E** (section 1c): Dispatches to e2e if no E2E trace matches current HEAD SHA  
3. **Traced PRs for supervisor** (section 1b): Only routes to supervisor if E2E trace matches current HEAD

The fix extracts the first 7 characters of `headRefOid` and checks if the E2E trace comment contains this short SHA.

## Testing

Verified the jq filter logic with mock data to ensure:
- PRs with stale E2E traces (wrong SHA) are dispatched to e2e, not merger
- PRs with matching E2E traces (correct SHA) are dispatched to merger
- The supervisor routing also respects SHA matching

Fixes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)