### PR TITLE
reviewer: persisted known-non-issues list to stop flagging the same false positives

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -6,6 +6,14 @@ You are the reviewer agent for gitbee.
 
 When an implementation PR is opened or updated, post a normal prose review comment. You are a second pair of eyes — your job is to catch what the drafter missed.
 
+## Known non-issues check
+
+**MANDATORY FIRST STEP:** Before posting any review, read `docs/reviewer-known-non-issues.md`. If any concern you would raise matches an entry in that document, either:
+1. Omit that finding from your review entirely, or
+2. If you must mention it, cite the known-non-issue entry and explain why this case is different
+
+This prevents repeatedly flagging the same false positives across runs.
+
 ## Fresh context rule
 
 You operate with **fresh context** on each invocation. Read the PR diff and linked issue at HEAD. While you may scan prior review comments to confirm resolutions, form your judgment independently without being biased by prior analysis.

--- a/docs/reviewer-known-non-issues.md
+++ b/docs/reviewer-known-non-issues.md
@@ -1,0 +1,21 @@
+# Reviewer Known Non-Issues
+
+This document maintains a curated list of patterns that the reviewer agent has previously flagged as issues but were determined by humans to be false positives. The reviewer must consult this document before posting any review to avoid repeating known false positives.
+
+## tick.sh reviewer-dispatch at lines ~344-348
+Not dead code. These are the live echo/return that dispatches reviewer role.
+Last flagged as false-positive on 2026-04-21 (PRs #731, #738).
+
+## Self-authored PRs can be approved via <!-- bee:approved-for-e2e --> marker
+See #746. Not a blocker — marker is the canonical approval path.
+Self-authored PRs cannot receive GitHub's `--approve` review state due to GitHub API limitations, but the bee:approved-for-e2e HTML comment marker serves as the canonical approval mechanism for the e2e agent.
+
+## How to maintain this document
+
+When a reviewer posts a finding that a human later rejects (comment "not actually an issue" + close without change), a follow-up drafter tick should add the pattern to this document.
+
+Each entry should include:
+- A clear heading describing the pattern
+- Explanation of why it's not actually an issue
+- Reference to when/where it was last incorrectly flagged
+- Any relevant context or background


### PR DESCRIPTION
**drafter:**

## Summary

Implements a persisted list of known non-issues that the reviewer agent must consult before posting any review, preventing it from repeatedly flagging the same false positives across runs.

## Changes

- Created `docs/reviewer-known-non-issues.md` with initial entries for two known false positives:
  - tick.sh reviewer-dispatch lines (incorrectly flagged as dead code)
  - Self-authored PR approval via bee:approved-for-e2e marker
- Updated `agents/reviewer.md` to add a mandatory first step requiring the reviewer to check the known-non-issues document before posting reviews

## Testing

The changes are configuration/documentation updates that will take effect when the reviewer agent runs. The reviewer will now:
1. Read the known-non-issues document before posting any review
2. Either omit findings that match known non-issues or cite why the case is different

Fixes #752