### PR TITLE
dispatcher: route merge conflicts to drafter for rebase, not merger

### DIFF
--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -224,19 +224,22 @@ pick_target() {
 
   local pr_basics
   pr_basics=$(gh pr list --repo "$REPO" --state open --search "sort:created-asc" --limit 50 \
-    --json number,reviewDecision,labels,reviews,comments,headRefOid 2>/dev/null || echo "[]")
+    --json number,reviewDecision,labels,reviews,comments,headRefOid,mergeable,mergeStateStatus 2>/dev/null || echo "[]")
   # Priority sort: priority:high first, then original (created-asc) order.
   pr_basics=$(echo "$pr_basics" | jq '[ .[] | . as $p | $p + {_prio: (if ($p.labels | map(.name) | index("priority:high")) then 0 else 1 end)} ] | sort_by(._prio) | map(del(._prio))')
 
   # 1. Approved PRs that also have a passing E2E trace → merger.
   # "Approved" = reviewDecision == APPROVED OR a review body contains the marker.
   # "E2E pass" = any PR issue-comment contains "**E2E trace (pass)**".
+  # IMPORTANT: Skip PRs with merge conflicts (mergeable: CONFLICTING or mergeStateStatus: DIRTY)
   local mergeable_prs
   mergeable_prs=$(echo "$pr_basics" | jq -r '
     .[]
     | . as $pr
     | select(.labels | map(.name) | index("breeze:wip") | not)
     | select(.labels | map(.name) | index("breeze:human") | not)
+    | select(.mergeable != "CONFLICTING")
+    | select(.mergeStateStatus != "DIRTY")
     | select(
         .reviewDecision == "APPROVED"
         or any(.reviews[]?.body // ""; contains("<!-- bee:approved-for-e2e -->"))
@@ -248,6 +251,29 @@ pick_target() {
   ' 2>/dev/null || true)
   if [[ -n "$mergeable_prs" ]]; then
     echo "merger $(echo "$mergeable_prs" | head -1)"
+    return
+  fi
+
+  # 1a'. Approved PRs with passing E2E but merge conflicts → drafter for rebase
+  # These PRs are ready to merge except they have conflicts with main
+  local conflicted_prs
+  conflicted_prs=$(echo "$pr_basics" | jq -r '
+    .[]
+    | . as $pr
+    | select(.labels | map(.name) | index("breeze:wip") | not)
+    | select(.labels | map(.name) | index("breeze:human") | not)
+    | select(.mergeable == "CONFLICTING" or .mergeStateStatus == "DIRTY")
+    | select(
+        .reviewDecision == "APPROVED"
+        or any(.reviews[]?.body // ""; contains("<!-- bee:approved-for-e2e -->"))
+        or any(.comments[]?.body // ""; contains("<!-- bee:approved-for-e2e -->"))
+      )
+    | select(any(.comments[]?.body // "";
+        (contains("**E2E trace (pass)**") and contains($pr.headRefOid[0:7]))))
+    | .number
+  ' 2>/dev/null || true)
+  if [[ -n "$conflicted_prs" ]]; then
+    echo "drafter $(echo "$conflicted_prs" | head -1)"
     return
   fi
 


### PR DESCRIPTION
**drafter:**

Fix hot-loop where merger was repeatedly dispatched on PRs with merge conflicts.

## Problem
As described in #755, when a PR has:
- Approval marker + passing E2E trace with matching SHA
- `mergeable: CONFLICTING` due to drift from main

The merger correctly refuses to merge, but the dispatcher re-picks merger on next tick, creating a hot-loop.

## Solution
Modified the dispatcher's `pick_target` function in `scripts/tick.sh` to:

1. Check `mergeable` and `mergeStateStatus` fields before dispatching to merger
2. Skip PRs with `mergeable: CONFLICTING` or `mergeStateStatus: DIRTY` when selecting for merger
3. Add a new routing rule that sends conflicted-but-approved PRs to drafter for rebasing

## Changes
- Added `mergeable` and `mergeStateStatus` to the PR data fetch
- Modified merger selection to exclude conflicted PRs  
- Added new section (1a') to route approved+E2E-passed+conflicted PRs to drafter

## Testing
- Tested jq queries locally to ensure they correctly identify conflicted PRs
- Verified PR #754 would be correctly routed to drafter instead of merger

Fixes #755