### PR TITLE
dispatch: finishing agent emits next-role hint instead of dispatcher re-guessing

### DIFF
--- a/agents/auditor.md
+++ b/agents/auditor.md
@@ -87,4 +87,8 @@ Same as other agents — acquire `breeze:wip` on the design-doc issue before aud
 ## Output
 
 End each run with a one-line status:
-`auditor: issue=<n> verdict=<all-shipped|gaps-found|skipped> <all-shipped → closed> <gaps-found → breeze:human>`.
+`auditor: issue=<n> verdict=<all-shipped|gaps-found|skipped> <all-shipped → closed> <gaps-found → breeze:human> next=<role|none>`.
+
+Next-role hints:
+- After closing issue or finding gaps: `next=none`
+- After skipping: `next=none`

--- a/agents/drafter.md
+++ b/agents/drafter.md
@@ -73,4 +73,10 @@ Before touching an item:
 
 ## Output
 
-End each run with a one-line status in stdout: `drafter: issue=<n> action=<claimed|drafted|implemented|done|gave-up-breeze-human>`.
+End each run with a one-line status in stdout: `drafter: issue=<n> action=<claimed|drafted|implemented|done|gave-up-breeze-human> next=<role|none>`.
+
+Next-role hints:
+- After implementing a PR: `next=reviewer`
+- After addressing review feedback: `next=reviewer` if changes made, `next=e2e` if already approved+fresh
+- After pausing for human: `next=none`
+- After closing an issue: `next=none`

--- a/agents/e2e-designer.md
+++ b/agents/e2e-designer.md
@@ -62,4 +62,8 @@ After you append the test plan:
 
 ## Output
 
-End with: `e2e-designer: issue=<n> action=<designed|revised|gave-up-breeze-human>`
+End with: `e2e-designer: issue=<n> action=<designed|revised|gave-up-breeze-human> next=<role|none>`.
+
+Next-role hints:
+- After designing or revising test plan: `next=e2e-supervisor`
+- After pausing for human: `next=none`

--- a/agents/e2e-supervisor.md
+++ b/agents/e2e-supervisor.md
@@ -95,4 +95,14 @@ When you classify a run as `design-trivial`:
 
 ## Output
 
-End with: `e2e-supervisor: pr=<n> action=<approved-plan|rejected-plan|classified-pass|classified-lazy|classified-code-bug|classified-test-bug|classified-design-trivial|classified-design-conflicting>`
+End with: `e2e-supervisor: pr=<n> action=<approved-plan|rejected-plan|classified-pass|classified-lazy|classified-code-bug|classified-test-bug|classified-design-trivial|classified-design-conflicting> next=<role|none>`.
+
+Next-role hints:
+- After classifying as pass: `next=merger`
+- After classifying as lazy-run: `next=e2e`
+- After classifying as code-bug: `next=drafter`
+- After classifying as test-bug: `next=e2e-designer`
+- After classifying as design-trivial: `next=e2e`
+- After classifying as design-conflicting: `next=none`
+- After approving plan: `next=drafter`
+- After rejecting plan: `next=e2e-designer`

--- a/agents/e2e.md
+++ b/agents/e2e.md
@@ -69,4 +69,9 @@ A second instance of the reviewer agent reads the trace tag (`trace-<short-sha>-
 
 ## Output
 
-Print to stdout on exit: `e2e: pr=<n> sandbox=<url> result=<pass|fail|incomplete|gave-up-breeze-human>`.
+Print to stdout on exit: `e2e: pr=<n> sandbox=<url> result=<pass|fail|incomplete|gave-up-breeze-human> next=<role|none>`.
+
+Next-role hints:
+- After passing E2E: `next=merger`
+- After failing E2E: `next=e2e-supervisor`
+- After incomplete or pausing for human: `next=none`

--- a/agents/merger.md
+++ b/agents/merger.md
@@ -38,4 +38,13 @@ Same as other agents — acquire `breeze:wip` on the PR before merging. Release 
 
 ## Output
 
-`merger: pr=<n> action=<merged|skipped-not-approved|skipped-no-e2e|skipped-stale-e2e|skipped-conflicts|skipped-already-merged|gave-up-breeze-human>`.
+`merger: pr=<n> action=<merged|skipped-not-approved|skipped-no-e2e|skipped-stale-e2e|skipped-conflicts|skipped-already-merged|gave-up-breeze-human> next=<role|none>`.
+
+Next-role hints:
+- After merging: `next=none`
+- After skipping due to conflicts: `next=drafter`
+- After skipping due to stale E2E: `next=e2e`
+- After skipping due to no approval: `next=reviewer`
+- After skipping due to no E2E: `next=e2e`
+- After pausing for human: `next=none`
+- After skipping already merged: `next=none`

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -54,4 +54,8 @@ If the design is unclear or contradictory:
 
 ## Output
 
-End with: `planner: issue=<n> action=<planned|escalated-too-many-prs|gave-up-breeze-human>`
+End with: `planner: issue=<n> action=<planned|escalated-too-many-prs|gave-up-breeze-human> next=<role|none>`.
+
+Next-role hints:
+- After planning: `next=e2e-designer`
+- After escalating or pausing for human: `next=none`

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -49,4 +49,10 @@ Same as drafter — check `breeze:wip` with fresh timestamp before taking over. 
 
 ## Output
 
-End each run with a one-line status: `reviewer: pr=<n> action=<approved|requested-changes|paused|skipped-already-reviewed>`.
+End each run with a one-line status: `reviewer: pr=<n> action=<approved|requested-changes|paused|skipped-already-reviewed> next=<role|none>`.
+
+Next-role hints:
+- After approving: `next=e2e`
+- After requesting changes: `next=drafter`
+- After pausing for human: `next=none`
+- After skipping already reviewed: `next=none`

--- a/scripts/activity.sh
+++ b/scripts/activity.sh
@@ -20,7 +20,8 @@
 #     "umbrella": "#7",            // inferred from Refs/Fixes in PR body; null otherwise
 #     "exit_code": 0,              // end events only
 #     "duration_s": 108,           // end events only
-#     "outcome": "requested-changes" // end events only; parsed from last agent comment
+#     "outcome": "requested-changes", // end events only; parsed from last agent comment
+#     "next": "drafter"            // end events only; next-role hint from agent output
 #   }
 #
 # Outcome is extracted from the last comment authored on the target whose body
@@ -62,6 +63,47 @@ resolve_target() {
     return
   fi
   printf 'unknown\t\t\n'
+}
+
+# Scrape the last agent output line for the next-role hint.
+# Format: "<agent>: <target>=<n> action=<outcome> next=<role|none>"
+# Returns the next role (e.g. "reviewer", "e2e", "none") or empty string if not found.
+scrape_next_hint() {
+  local repo="$1" number="$2" agent="$3"
+
+  # Look for the agent's output in the last comment/review that starts with **<agent>:
+  local bodies=""
+  local reviews_json
+  reviews_json=$(gh pr view "$number" --repo "$repo" --json reviews 2>/dev/null || echo "")
+  if [[ -n "$reviews_json" ]]; then
+    local review_bodies
+    review_bodies=$(jq -r '[.reviews[]? | {ts: .submittedAt, body: (.body // "")}]' <<<"$reviews_json" 2>/dev/null || echo "[]")
+    bodies="$review_bodies"
+  fi
+  local comments_json
+  comments_json=$(gh issue view "$number" --repo "$repo" --json comments 2>/dev/null || echo "")
+  if [[ -n "$comments_json" ]]; then
+    local comment_bodies
+    comment_bodies=$(jq -r '[.comments[]? | {ts: .createdAt, body: (.body // "")}]' <<<"$comments_json" 2>/dev/null || echo "[]")
+    bodies=$(jq -s '.[0] + .[1]' <(echo "${bodies:-[]}") <(echo "$comment_bodies") 2>/dev/null || echo "[]")
+  fi
+  [[ -z "$bodies" || "$bodies" == "[]" ]] && { echo ""; return; }
+
+  # Look for the pattern: <agent>: ...<target>=<n> ... next=<role|none>
+  # in the agent's last comment
+  local next_hint=""
+  next_hint=$(jq -r --arg agent "$agent" --arg number "$number" '
+    sort_by(.ts) | reverse
+    | map(select(.body | test("^\\*\\*" + $agent + ":")))
+    | .[0].body // ""
+    | split("\n")
+    | map(select(test($agent + ":.*\\b(pr|issue)=" + $number + "\\b.*\\bnext=")))
+    | .[0] // ""
+    | capture("\\bnext=(?<hint>[a-z-]+|none)") // {hint: ""}
+    | .hint
+  ' <<<"$bodies" 2>/dev/null || echo "")
+
+  echo "$next_hint"
 }
 
 # Scrape the last agent-prefixed body for an outcome token.
@@ -166,12 +208,13 @@ cmd_start() {
 
 cmd_end() {
   local repo="$1" kind="$2" number="$3" agent_id="$4" exit_code="$5" duration_s="$6"
-  local meta target_kind title umbrella outcome
+  local meta target_kind title umbrella outcome next_hint
   meta=$(resolve_target "$repo" "$number")
   target_kind=$(cut -f1 <<<"$meta")
   title=$(cut -f2 <<<"$meta")
   umbrella=$(cut -f3 <<<"$meta")
   outcome=$(scrape_outcome "$repo" "$number" "$kind")
+  next_hint=$(scrape_next_hint "$repo" "$number" "$kind")
 
   local json
   json=$(jq -cn \
@@ -184,6 +227,7 @@ cmd_end() {
     --arg title "$title" \
     --arg umbrella "$umbrella" \
     --arg outcome "$outcome" \
+    --arg next_hint "$next_hint" \
     --argjson exit_code "$exit_code" \
     --argjson duration_s "$duration_s" \
     '{
@@ -198,7 +242,8 @@ cmd_end() {
       umbrella: (if $umbrella == "" then null else $umbrella end),
       exit_code: $exit_code,
       duration_s: $duration_s,
-      outcome: (if $outcome == "" then null else $outcome end)
+      outcome: (if $outcome == "" then null else $outcome end),
+      next: (if $next_hint == "" then null elif $next_hint == "none" then null else $next_hint end)
     }')
   write_event "$json"
 }

--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -635,7 +635,92 @@ check_drafter_closed_pr() {
   return 1
 }
 
-target=$(pick_target)
+# Check for next-role hint from the last agent that finished on this target.
+# Returns the next role to dispatch, or empty string if no hint or hint is "none".
+check_next_hint() {
+  local number="$1"
+  local activity_log="${LOG_DIR}/activity.ndjson"
+
+  [[ ! -f "$activity_log" ]] && { echo ""; return; }
+
+  # Get the last end event for this target with a non-null next field
+  local next_role
+  next_role=$(jq -r --arg target "#${number}" '
+    select(.event == "end" and .target == $target and .next != null) |
+    .next
+  ' "$activity_log" 2>/dev/null | tail -1)
+
+  echo "$next_role"
+}
+
+# Check if we should skip the hint to prevent same-role loops.
+# Returns 0 if we should skip (same role hinted twice in a row), 1 otherwise.
+check_hint_loop() {
+  local hint_role="$1" number="$2"
+  local activity_log="${LOG_DIR}/activity.ndjson"
+
+  [[ ! -f "$activity_log" ]] && return 1
+
+  # Get the last two end events for this target with non-null next hints
+  local last_two_hints
+  last_two_hints=$(jq -r --arg target "#${number}" '
+    select(.event == "end" and .target == $target and .next != null) |
+    "\(.agent):\(.next)"
+  ' "$activity_log" 2>/dev/null | tail -2)
+
+  # If we have exactly 2 hints and both point to the same role, skip the hint
+  local hint_count=$(echo "$last_two_hints" | wc -l | xargs)
+  if [[ "$hint_count" == "2" ]]; then
+    local prev_hint=$(echo "$last_two_hints" | head -1 | cut -d: -f2)
+    local curr_hint=$(echo "$last_two_hints" | tail -1 | cut -d: -f2)
+    if [[ "$prev_hint" == "$hint_role" && "$curr_hint" == "$hint_role" ]]; then
+      log "ANTI-LOOP: same role '$hint_role' hinted twice for #$number, falling back to pick_target"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+# First check for next-role hint before running pick_target
+target=""
+hint_target=""
+
+# Get all open issues and PRs that might need work
+all_targets=$(( \
+  gh issue list --repo "$REPO" --state open --limit 50 --json number --jq '.[].number' 2>/dev/null; \
+  gh pr list --repo "$REPO" --state open --limit 50 --json number --jq '.[].number' 2>/dev/null \
+) | sort -u)
+
+# Check each target for a next-role hint
+for t in $all_targets; do
+  # Skip if target has breeze:wip or breeze:human
+  labels=$(gh issue view "$t" --repo "$REPO" --json labels --jq '.labels | map(.name) | join(",")' 2>/dev/null || echo "")
+  if echo "$labels" | grep -qE "breeze:(wip|human)"; then
+    continue
+  fi
+
+  hint=$(check_next_hint "$t")
+  if [[ -n "$hint" && "$hint" != "none" ]]; then
+    # Check anti-loop safety
+    if ! check_hint_loop "$hint" "$t"; then
+      hint_target="$hint $t"
+      log "dispatch: using hint from activity log - $hint on #$t"
+      break
+    fi
+  fi
+done
+
+# If we have a hint, use it; otherwise fall back to pick_target
+if [[ -n "$hint_target" ]]; then
+  target="$hint_target"
+  log "dispatch: kind=${hint_target%% *} target=#${hint_target##* } source=hint"
+else
+  target=$(pick_target)
+  if [[ -n "$target" ]]; then
+    log "dispatch: kind=${target%% *} target=#${target##* } source=pick_target"
+  fi
+fi
 
 if [[ -z "$target" ]]; then
   # Pause-don't-stop: distinguish "all open work paused on human" from
@@ -695,7 +780,7 @@ The drafter is forbidden from closing PRs it was dispatched to work on (see #719
   exit 0
 fi
 
-log "dispatch: kind=$kind target=#$number"
+# Dispatch source was already logged when target was selected
 DISPATCH_START_TS=$SECONDS
 
 # Acquire claim BEFORE spawning, so concurrent ticks don't dispatch twice


### PR DESCRIPTION
**drafter:**

## Summary

Implements next-role hints to eliminate hot-loops where pick_target's label/state inference disagrees with the finishing agent's knowledge about what should come next.

## Changes

- **Agent prompts**: All agents now emit `next=<role|none>` in their output line
- **Activity logging**: activity.sh parses the hint from agent output and stores it in the activity log
- **Dispatcher logic**: tick.sh checks for hints before falling back to pick_target
- **Anti-loop safety**: Same role cannot be hinted twice in a row for the same target

## Implementation Details

### Agent Output Format
Each agent now outputs: `<agent>: <target>=<n> action=<outcome> next=<role|none>`

Examples:
- `merger: pr=754 action=skipped-merge-conflict next=drafter`
- `merger: pr=753 action=skipped-stale-e2e next=e2e`
- `reviewer: pr=745 action=requested-changes next=drafter`
- `e2e: pr=735 action=pass next=merger`

### Dispatcher Flow
1. Check all open items for next-role hints in activity log
2. Skip items with breeze:wip or breeze:human labels
3. If hint found and not "none", check anti-loop safety
4. If safe, dispatch hinted role; otherwise fall back to pick_target

### Anti-loop Protection
If the same role has been hinted twice in a row for the same target, the hint is ignored and pick_target is used instead. This prevents infinite loops from buggy agent logic.

## Testing

Created and ran test script to verify:
- Hint extraction from activity log works correctly
- Anti-loop detection triggers when same role is hinted twice

## Impact

This change subsumes/fixes:
- #744 (stale-SHA merger loop) — merger emits `next=e2e`
- #755 (conflict merger loop) — merger emits `next=drafter`
- Parts of #734/#739/#746 — reviewer can hint `next=drafter` when requesting changes

Fixes #756