### PR TITLE
fix(dispatcher): stop log contamination of pick_target stdout + route issue-with-open-PR to the PR

### DIFF
--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -25,7 +25,7 @@ TICK_HISTORY="${LOG_DIR}/tick-history.log"
 ROLLBACK_MARKER="${LOG_DIR}/ROLLBACK"
 mkdir -p "$LOG_DIR"
 
-log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" | tee -a "$LOG"; }
+log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" | tee -a "$LOG" >&2; }
 
 # Last-failure persistence functions (issue #751)
 FAILURE_DIR="${LOG_DIR}/last-failure"
@@ -777,8 +777,9 @@ pick_target() {
     local linked_pr
     linked_pr=$(gh pr list --repo "$REPO" --state open --search "$n in:body" --json number --jq '.[0].number' 2>/dev/null || echo "")
     if [[ -n "$linked_pr" ]]; then
-      log "ERROR: issue #$n already has open PR #$linked_pr linked to it — dispatcher should have picked PR for revision, not issue"
-      continue  # Skip to next issue
+      log "redirecting issue #$n to its open PR #$linked_pr for revision"
+      echo "drafter $linked_pr"
+      return
     fi
     echo "drafter $n"
     return


### PR DESCRIPTION
**human:**

Fixes #773.

Two bugs made the dispatcher wedge silently:

## Bug 1: log() leaked onto stdout

```bash
# Before:
log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" | tee -a "$LOG"; }

# After:
log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" | tee -a "$LOG" >&2; }
```

`tee` was writing to both the log file AND stdout. When `pick_target` called `log` (e.g. the "issue has open PR" branch at line 780), the log line leaked into the caller's `target=$(pick_target)` capture, turning the timestamp into the "role" name:

```
2026-04-22T22:28:36Z dispatch: kind=2026-04-22T22:28:35Z target=#31
2026-04-22T22:28:37Z ERROR: no role prompt at /Users/keyitan/git-bee/agents/2026-04-22T22:28:35Z.md
```

Redirecting tee output to stderr fixes it. Log file still captures everything; terminal still shows it (stderr is still visible). Only `$(...)` captures are now clean.

## Bug 2: issue-with-open-PR fell through instead of redirecting

```bash
# Before:
if [[ -n "$linked_pr" ]]; then
  log "ERROR: issue #$n already has open PR #$linked_pr linked to it..."
  continue  # Skip to next issue
fi

# After:
if [[ -n "$linked_pr" ]]; then
  log "redirecting issue #$n to its open PR #$linked_pr for revision"
  echo "drafter $linked_pr"
  return
fi
```

This matches `agents/drafter.md` §0 — "before ANY branch creation or PR work, check for existing PRs" — the dispatcher now honors the same rule at pick time. Emits `drafter <pr_number>` so the existing PR gets picked up for revision.

## Not addressed in this PR

- Watchdog (`bee health` command) — filed under #773 as a follow-up, belongs in a separate PR.
- `outcome=null` parse bug — #771, unrelated.
- Rollback-loop — #770, unrelated.

## Test

Manual repro: before this fix, having an open issue with a linked PR causes every tick to exit `no-role-prompt`. After this fix, the dispatcher routes to the PR for revision.

Automated test would require mocking `gh` calls — skipping for now. If wanted, I can add one.