### PR TITLE
Fix rollback loop: check ROLLBACK marker before crash detector

### DIFF
--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -137,6 +137,14 @@ trap record_tick_exit EXIT
 # Capture current SHA at start
 TICK_START_SHA=$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
+# Guard -1 (moved up): ROLLBACK marker — if it exists, exit early without dispatching
+# This must run BEFORE the crash detector to prevent rollback loops
+if [[ -f "$ROLLBACK_MARKER" ]]; then
+  log "ROLLBACK marker exists — ticks paused. Remove $ROLLBACK_MARKER to resume."
+  log "tick end (pid=$$ exit=rollback-marker)"
+  exit 0
+fi
+
 # Guard -0: 3-consecutive-crash detector
 if [[ -f "$TICK_HISTORY" ]]; then
   # Count non-zero exits in last 3 ticks (Guard 0 exits with 0 by design)
@@ -232,13 +240,6 @@ EOF
       fi
     fi
   fi
-fi
-
-# Guard -1: ROLLBACK marker — if it exists, exit early without dispatching
-if [[ -f "$ROLLBACK_MARKER" ]]; then
-  log "ROLLBACK marker exists — ticks paused. Remove $ROLLBACK_MARKER to resume."
-  log "tick end (pid=$$ exit=rollback-marker)"
-  exit 0
 fi
 
 # Guard 0: credential healthcheck. A tick that runs with expired gh auth


### PR DESCRIPTION
**drafter:**

## Summary

This PR fixes the rollback loop issue where the crash detector would repeatedly trigger even after a rollback had already been applied. The root cause was that the crash detector (Guard -0) was running before the ROLLBACK marker check (Guard -1).

## What changed

- Moved the ROLLBACK marker check to run **before** the crash detector in `scripts/tick.sh`
- Added clear comments explaining why this ordering is critical
- The tick now exits cleanly with code 0 when the ROLLBACK marker exists, preventing further pollution of tick-history.log

## Testing

- Syntax validated with `bash -n scripts/tick.sh`
- Created and ran a test script to verify the logic flow
- The fix ensures that when a ROLLBACK marker exists, the tick exits immediately without running the crash detector

## Why this matters

Without this fix, once a rollback was triggered due to 3 consecutive crashes:
1. The ROLLBACK marker would be created
2. But the next tick would still run the crash detector first
3. It would see 3 failures in history and trigger another rollback
4. This would repeat every 30 seconds, spamming logs and masking the real issue

Now with the fix:
1. If ROLLBACK marker exists, tick exits immediately with code 0
2. No crash detection runs while paused
3. Clean exit prevents adding more failures to tick-history.log
4. Breaking the loop allows proper investigation of the root cause

Fixes #770

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>