### PR TITLE
fix(tick): drop 10 top-level 'local' declarations (regression #782)

### DIFF
--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -1362,7 +1362,7 @@ if [[ "${GIT_BEE_UI:-}" == "tmux" ]] && command -v tmux >/dev/null 2>&1 && tmux 
   log "dispatching ${kind} to tmux window '${kind}-#${number}'"
 
   # Write prompt to temp file to avoid shell escaping issues
-  local prompt_file="/tmp/git-bee-prompt-${kind}-${number}.txt"
+  prompt_file="/tmp/git-bee-prompt-${kind}-${number}.txt"
   echo "$prompt" > "$prompt_file"
 
   # Create new window and run claude with the prompt file
@@ -1389,18 +1389,18 @@ else
   # Original headless mode
   if [[ "$kind" == "e2e" ]]; then
     # Write prompt to temp file for wrapper
-    local prompt_file="/tmp/git-bee-prompt-${kind}-${number}.txt"
+    prompt_file="/tmp/git-bee-prompt-${kind}-${number}.txt"
     echo "$prompt" > "$prompt_file"
 
     # Use wrapper for e2e agent to capture metrics
-    local output_file="/tmp/git-bee-agent-output-$$"
+    output_file="/tmp/git-bee-agent-output-$$"
     "$HERE/e2e-agent-wrapper.sh" "$number" "$prompt_file" 2>&1 | tee "$output_file" | tee -a "$LOG" || {
       exit_code=$?
 
       # Parse agent's stdout for outcome and next hint
-      local agent_outcome="" agent_next=""
+      agent_outcome="" agent_next=""
       if [[ -f "$output_file" ]]; then
-        local status_line
+        status_line
         status_line=$(grep -E "^${kind}:" "$output_file" | tail -1 || echo "")
         if [[ -n "$status_line" ]]; then
           # Parse outcome field (could be action=, result=, or verdict=)
@@ -1428,9 +1428,9 @@ else
       exit "$exit_code"
     }
     # Parse agent's stdout for successful e2e run
-    local agent_outcome="" agent_next=""
+    agent_outcome="" agent_next=""
     if [[ -f "$output_file" ]]; then
-      local status_line
+      status_line
       status_line=$(grep -E "^${kind}:" "$output_file" | tail -1 || echo "")
       if [[ -n "$status_line" ]]; then
         # Parse outcome field (could be action=, result=, or verdict=)
@@ -1442,15 +1442,15 @@ else
     rm -f "$prompt_file" "$output_file"
   else
     # Capture agent output to parse the status line
-    local output_file="/tmp/git-bee-agent-output-$$"
+    output_file="/tmp/git-bee-agent-output-$$"
     "$CLAUDE_BIN" -p "$prompt" --permission-mode bypassPermissions 2>&1 | tee "$output_file" | tee -a "$LOG" || {
       exit_code=$?
       log "agent exited non-zero (${exit_code}) for #${number}"
 
       # Parse agent's stdout for outcome and next hint
-      local agent_outcome="" agent_next=""
+      agent_outcome="" agent_next=""
       if [[ -f "$output_file" ]]; then
-        local status_line
+        status_line
         status_line=$(grep -E "^${kind}:" "$output_file" | tail -1 || echo "")
         if [[ -n "$status_line" ]]; then
           # Parse outcome field (could be action=, result=, or verdict=)


### PR DESCRIPTION
**human:**

Fixes #782.

#778's dispatch rewrite introduced 10 more top-level `local` statements in the non-function dispatch region (lines 1365, 1392, 1396, 1401, 1403, 1431, 1433, 1445, 1451, 1453). Under `set -euo pipefail`, each errors immediately with `local: can only be used in a function`, causing the tick to exit right after logging `spawning claude` but before claude actually runs.

Confirmed reproduction via `bash -x scripts/tick.sh`:
```
+ [[ drafter == \e\2\e ]]
+ local output_file=/tmp/git-bee-agent-output-76036
scripts/tick.sh: line 1445: local: can only be used in a function
+ release_all
```

Fix: drop `local` from all 10 — they're plain assignments, no semantic change at top level.

This is the 6-through-15th top-level `local` from the #778 regression. I fixed 5 earlier in scattered commits (PR #778 itself landed with subsequent inline fixes). This PR completes the cleanup.

## Verification

- `bash -n scripts/tick.sh` passes.
- Python scanner finds 0 remaining top-level `local` declarations.
- Manual trace confirms script now gets past line 1445 without erroring.

After this lands + launchd is re-loaded, the dispatcher should actually run claude and produce real drafter work.