### PR TITLE
fix(dispatch): route PRs with bee:changes-requested marker to drafter (#780)

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -50,7 +50,7 @@ Scan previous reviews at this PR. If something you would flag was already raised
 - **Write prose, not verdict tables.** No `ALIGNED / CONFLICT` labels. After the verdict header and blank line, write a normal GitHub review comment like a human reviewer would write.
 - **Do not push fixes yourself.** You are the reviewer. The drafter handles feedback on its next tick.
 - **Do not merge.** Even on approve, merging is the drafter's job (or the human's).
-- **One review per PR state.** If you already reviewed at the current HEAD SHA, skip. Re-review only when new commits land.
+- **One review per PR state.** If you already reviewed at the current HEAD SHA, skip. Re-review only when new commits land. When skipping, exit silently — **do NOT re-apply `breeze:human`, do NOT call `bee pause`, do NOT post any comment**. Leave whatever label state is there. A human who removed `breeze:human` to re-dispatch expects the loop to advance, not to bounce the label back (see #780 — the PR wedged because every skip re-labeled `breeze:human`).
 
 ## When blocked
 

--- a/scripts/bee
+++ b/scripts/bee
@@ -42,6 +42,7 @@ Usage:
   bee status             Print a terse three-section status block
   bee status --json      Same data, JSON-encoded
   bee pause <n> <reason> Label issue/PR #n with breeze:human and comment
+  bee request-changes <n> [reason]  Post a bee:changes-requested marker on PR #n (routes to drafter)
   bee config get [key]   Get configuration value(s)
   bee config set <key> <value>  Set a configuration value
   bee config add <key> <value>  Add value to list config
@@ -456,6 +457,39 @@ EOF
   echo "bee pause: labeled #${number} with breeze:human"
 }
 
+# Post a bee:changes-requested marker comment on PR #n. In single-account mode
+# (#754) this is the human-side revision-request signal — dispatcher sees the
+# marker and routes to drafter on the next tick. See #780.
+cmd_request_changes() {
+  local number="${1:-}"
+  local reason="${2:-Please address the feedback above.}"
+
+  if [[ -z "$number" ]]; then
+    echo "bee request-changes: missing PR number" >&2
+    echo "usage: bee request-changes <n> [reason]" >&2
+    exit 2
+  fi
+
+  if ! [[ "$number" =~ ^[0-9]+$ ]]; then
+    echo "bee request-changes: invalid PR number: $number" >&2
+    exit 2
+  fi
+
+  gh pr comment "$number" --repo "$REPO" --body "$(cat <<EOF
+**human:** changes requested
+
+${reason}
+
+<!-- bee:changes-requested -->
+EOF
+)" >/dev/null
+
+  # Ensure breeze:human is NOT set so the dispatcher can pick this up.
+  gh issue edit "$number" --repo "$REPO" --remove-label "breeze:human" >/dev/null 2>&1 || true
+
+  echo "bee request-changes: posted marker on #${number}"
+}
+
 CONFIG_FILE="${HOME}/.git-bee/config.json"
 
 cmd_config() {
@@ -845,6 +879,7 @@ main() {
     status)       cmd_status "$@" ;;
     log)          cmd_log "$@" ;;
     pause)        cmd_pause "$@" ;;
+    request-changes) cmd_request_changes "$@" ;;
     config)       cmd_config "$@" ;;
     watch)        cmd_watch "$@" ;;
     exclude)      cmd_exclude "$@" ;;

--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -417,6 +417,34 @@ has_human_approval() {
   return 1
 }
 
+# Returns 0 if PR has a human revision-request marker in a comment at/after
+# HEAD SHA timestamp. This is the revision-direction counterpart to the
+# bee:approved-for-e2e escape hatch: in single-account mode (#754) humans
+# cannot post formal `--request-changes` reviews on their own PRs, so the
+# dispatcher needs a way to recognize "please fix this" intent in comments.
+# See #780.
+has_human_revision_request() {
+  local pr_json="$1"
+  local pr_head_sha="$2"
+
+  local head_timestamp
+  head_timestamp=$(git -C "$REPO_ROOT" show -s --format=%ct "$pr_head_sha" 2>/dev/null || echo "0")
+
+  local has_marker_in_comments
+  has_marker_in_comments=$(echo "$pr_json" | jq --arg head_ts "$head_timestamp" '
+    any(.comments[]?;
+      (.body // "" | contains("<!-- bee:changes-requested -->")) and
+      ((.createdAt // "" | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) >= ($head_ts | tonumber))
+    )
+  ' 2>/dev/null || echo "false")
+
+  if [[ "$has_marker_in_comments" == "true" ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
 pick_target() {
   # Emits "<kind> <number>" to stdout, nothing if idle.
   # Note: --state open excludes MERGED/CLOSED PRs per first-tree classifier precedence.
@@ -630,6 +658,32 @@ pick_target() {
   pr_rows=$(gh pr list --repo "$REPO" --state open --search "sort:created-asc" --limit 50 \
     --json number,reviewDecision,labels,reviews,headRefOid,comments 2>/dev/null || echo "[]")
   pr_rows=$(echo "$pr_rows" | jq '[ .[] | . as $p | $p + {_prio: (if ($p.labels | map(.name) | index("priority:high")) then 0 else 1 end)} ] | sort_by(._prio) | map(del(._prio))')
+
+  # 2-pre. PRs with a human revision-request marker at/after HEAD → drafter.
+  # In single-account mode (#754) humans can't file formal --request-changes
+  # reviews on their own PRs, so a `<!-- bee:changes-requested -->` comment is
+  # the only way to signal revision intent. Must be checked before branch 2a:
+  # otherwise the dispatcher would route to reviewer, the reviewer would see a
+  # prior review at HEAD, skip, and re-apply breeze:human — wedging the PR (#780).
+  local revision_prs=""
+  while IFS= read -r pr; do
+    [[ -z "$pr" ]] && continue
+    local pr_num=$(echo "$pr" | jq -r '.number')
+    local pr_sha=$(echo "$pr" | jq -r '.headRefOid')
+    local has_wip=$(echo "$pr" | jq -r '.labels | map(.name) | index("breeze:wip") // false' 2>/dev/null || echo "false")
+    local has_human=$(echo "$pr" | jq -r '.labels | map(.name) | index("breeze:human") // false' 2>/dev/null || echo "false")
+    local has_quarantine=$(echo "$pr" | jq -r '.labels | map(.name) | index("breeze:quarantine-hotloop") // false' 2>/dev/null || echo "false")
+
+    if [[ "$has_wip" == "false" && "$has_human" == "false" && "$has_quarantine" == "false" ]]; then
+      if has_human_revision_request "$pr" "$pr_sha"; then
+        revision_prs="${revision_prs}${pr_num}"$'\n'
+      fi
+    fi
+  done < <(echo "$pr_rows" | jq -c '.[]' 2>/dev/null)
+  if [[ -n "$revision_prs" ]]; then
+    echo "drafter $(echo "$revision_prs" | head -1)"
+    return
+  fi
 
   local unreviewed_prs=""
   while IFS= read -r pr; do


### PR DESCRIPTION
**drafter:**

Fixes #780.

## Summary

In single-account mode (#754) humans can't file GitHub `--request-changes` reviews on their own PRs, so revision intent must come through comments. The dispatcher only consulted `reviews[]`, leaving PRs wedged: branch 2a routed to reviewer, reviewer skipped as already-reviewed and re-applied `breeze:human`, loop repeated.

Implements Option A from the design doc — HTML marker symmetric with the existing `bee:approved-for-e2e` escape hatch.

## Changes

- **`scripts/tick.sh`**: new `has_human_revision_request` helper + new dispatcher branch 2-pre that fires before 2a. When a PR has a `<!-- bee:changes-requested -->` comment at/after HEAD SHA timestamp, route to drafter.
- **`agents/reviewer.md`**: on `skipped-already-reviewed`, exit silently — do NOT re-apply `breeze:human`, do NOT pause, do NOT comment. This removes the second half of the loop the issue describes.
- **`scripts/bee`**: new `bee request-changes <n> [reason]` subcommand that posts the marker comment and clears `breeze:human` so the next tick dispatches drafter.

## Test plan

- [x] `bash -n` syntax check on tick.sh and bee
- [x] Verified jq logic for timestamp comparison (marker after HEAD → true; marker before HEAD → false)
- [ ] Next live human revision round: `bee request-changes <n> "fix this"` → dispatcher routes drafter on next tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)