### PR TITLE
fix: Clean up stale breeze labels on merge/close

### DIFF
--- a/agents/auditor.md
+++ b/agents/auditor.md
@@ -50,7 +50,7 @@ If any of those preconditions no longer hold when you start, exit with `auditor:
   - `**auditor: gaps-found**` (any 🟡/❌ — handing to human)
   - `**auditor: skipped — <reason>**` (preconditions no longer hold)
   Then a blank line, then the report.
-- **Close only on all-✅.** If every PR is ✅ or 📝-with-justification, close the issue (GitHub-CLOSED derives `done` per the state machine — no `breeze:done` label needed). Otherwise transition the issue via `set_breeze_state <repo> <n> human` and leave it open. Never call `gh edit --add-label breeze:*` directly — see `AGENTS.md`.
+- **Close only on all-✅.** If every PR is ✅ or 📝-with-justification, call `set_breeze_state <repo> <n> done` then close the issue. Otherwise transition the issue via `set_breeze_state <repo> <n> human` and leave it open. Never call `gh edit --add-label breeze:*` directly — see `AGENTS.md`.
 - **Never re-open a closed issue.** If you run on a closed issue, exit skipped.
 - **Do not modify the design-doc body.** You are read-only on the doc. Corrections belong in a follow-up PR.
 - **Do not approve, merge, or close PRs.** Your scope is the umbrella issue only.

--- a/agents/merger.md
+++ b/agents/merger.md
@@ -27,10 +27,12 @@ When a PR is approved AND has a passing E2E trace, merge it.
   - The E2E trace comment's sandbox short-SHA matches the PR's current HEAD short-SHA
   - The PR is mergeable (no conflicts, CI green if any)
 - **Use squash merge** with the PR title as the commit subject: `gh pr merge <n> --squash --delete-branch`.
-- **After merge:** scan the PR body for `Fixes #N` / `Closes #N`. For each linked issue:
-  - Label `breeze:done`
-  - Close if not already closed
-  - Comment: `**merger: merged**\n\nImplemented by PR #<pr>. Merged at <sha>.`
+- **After merge:**
+  - Call `set_breeze_state <repo> <pr> done` to transition the PR to breeze:done
+  - Scan the PR body for `Fixes #N` / `Closes #N`. For each linked issue:
+    - Label `breeze:done`
+    - Close if not already closed
+    - Comment: `**merger: merged**\n\nImplemented by PR #<pr>. Merged at <sha>.`
 - **Never re-open a merged PR** or un-label anything. Merger is a one-way door.
 
 ## When blocked

--- a/scripts/cleanup-stale-labels.sh
+++ b/scripts/cleanup-stale-labels.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# One-time cleanup script for stale breeze:* labels on closed/merged items
+# Run this once to clean up existing label drift before the janitor takes over
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$HERE/labels.sh"
+
+REPO="${1:-serenakeyitan/git-bee}"
+
+echo "Cleaning up stale breeze labels on repo: $REPO"
+
+# Clean up closed issues
+echo "Checking closed issues..."
+stale_issues=$(gh issue list --repo "$REPO" --state closed --limit 100 --json number,labels \
+  --jq '[.[] | select(.labels | map(.name) | any(test("breeze:(human|wip|new)")))] | .[].number' 2>/dev/null || echo "")
+
+if [[ -n "$stale_issues" ]]; then
+  echo "Found stale labels on closed issues: $stale_issues"
+  for n in $stale_issues; do
+    echo "  Transitioning issue #$n to breeze:done"
+    set_breeze_state "$REPO" "$n" done
+  done
+else
+  echo "No stale labels found on closed issues"
+fi
+
+# Clean up merged PRs
+echo "Checking merged PRs..."
+stale_prs=$(gh pr list --repo "$REPO" --state merged --limit 100 --json number,labels \
+  --jq '[.[] | select(.labels | map(.name) | any(test("breeze:(human|wip|new)")))] | .[].number' 2>/dev/null || echo "")
+
+if [[ -n "$stale_prs" ]]; then
+  echo "Found stale labels on merged PRs: $stale_prs"
+  for n in $stale_prs; do
+    echo "  Transitioning PR #$n to breeze:done"
+    set_breeze_state "$REPO" "$n" done
+  done
+else
+  echo "No stale labels found on merged PRs"
+fi
+
+# Clean up closed (not merged) PRs
+echo "Checking closed PRs..."
+closed_prs=$(gh pr list --repo "$REPO" --state closed --limit 100 --json number,labels,merged \
+  --jq '[.[] | select((.merged == false) and (.labels | map(.name) | any(test("breeze:(human|wip|new)"))))] | .[].number' 2>/dev/null || echo "")
+
+if [[ -n "$closed_prs" ]]; then
+  echo "Found stale labels on closed PRs: $closed_prs"
+  for n in $closed_prs; do
+    echo "  Transitioning PR #$n to breeze:done"
+    set_breeze_state "$REPO" "$n" done
+  done
+else
+  echo "No stale labels found on closed PRs"
+fi
+
+echo "Cleanup complete!"

--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -364,6 +364,55 @@ check_tiny_fix() {
   return 0
 }
 
+# Janitor: Clean up stale breeze labels on closed/merged items
+# This fixes the issue where merged PRs retain pre-merge breeze:* labels
+janitor_label_cleanup() {
+  # Only run if enabled
+  if [[ "${GIT_BEE_JANITOR:-1}" != "1" ]]; then
+    return
+  fi
+
+  log "running janitor label cleanup"
+
+  # Source labels.sh for set_breeze_state function
+  # shellcheck disable=SC1091
+  source "$HERE/labels.sh"
+
+  # Clean up closed issues with stale breeze labels
+  local stale_issues
+  stale_issues=$(gh issue list --repo "$REPO" --state closed --json number,labels \
+    --jq '[.[] | select(.labels | map(.name) | any(test("breeze:(human|wip|new)")))] | .[].number' 2>/dev/null || echo "")
+
+  if [[ -n "$stale_issues" ]]; then
+    for n in $stale_issues; do
+      log "janitor: transitioning closed issue #$n to breeze:done"
+      set_breeze_state "$REPO" "$n" done
+    done
+  fi
+
+  # Clean up merged/closed PRs with stale breeze labels
+  local stale_prs
+  stale_prs=$(gh pr list --repo "$REPO" --state merged --json number,labels \
+    --jq '[.[] | select(.labels | map(.name) | any(test("breeze:(human|wip|new)")))] | .[].number' 2>/dev/null || echo "")
+
+  # Also check closed (not just merged) PRs
+  local closed_prs
+  closed_prs=$(gh pr list --repo "$REPO" --state closed --json number,labels,merged \
+    --jq '[.[] | select((.merged == false) and (.labels | map(.name) | any(test("breeze:(human|wip|new)"))))] | .[].number' 2>/dev/null || echo "")
+
+  stale_prs="${stale_prs}${stale_prs:+ }${closed_prs}"
+
+  if [[ -n "$stale_prs" ]]; then
+    for n in $stale_prs; do
+      log "janitor: transitioning closed/merged PR #$n to breeze:done"
+      set_breeze_state "$REPO" "$n" done
+    done
+  fi
+}
+
+# Run janitor cleanup before finding work
+janitor_label_cleanup
+
 # Guard 2: find work
 # Priority order (PRs beat issues — if an issue already has a linked PR,
 # the PR is the next actionable step):


### PR DESCRIPTION
**drafter:**

Fixes #781 - implementing cleanup for stale breeze labels on merged/closed items