### PR TITLE
fix: Add self-authored escape hatch handling to supervisor verdict check

### DIFF
--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -582,6 +582,51 @@ pick_target() {
     # Check acceptable pairings
     if [[ "$marker_action" == "approved" ]] && [[ "$gh_state" == "APPROVED" ]]; then
       decision="advance"
+    elif [[ "$marker_action" == "approved" ]] && [[ "$gh_state" == "COMMENTED" ]]; then
+      # Check for self-authored escape hatch (issue #786, PR #787)
+      local pr_data
+      pr_data=$(gh pr view "$pr_number" --repo "$REPO" --json author,reviews,comments 2>/dev/null || echo "{}")
+      local pr_author=$(echo "$pr_data" | jq -r '.author.login // ""')
+      local current_user=$(gh api user --jq '.login' 2>/dev/null || echo "")
+
+      # Check if PR is self-authored and has the escape hatch marker
+      local has_marker="false"
+      if [[ "$pr_author" == "$current_user" ]] && [[ -n "$pr_author" ]]; then
+        # Look for bee:approved-for-e2e marker in reviews and comments
+        has_marker=$(echo "$pr_data" | jq -r '
+          (any(.reviews[]?.body // ""; contains("bee:approved-for-e2e")) or
+           any(.comments[]?.body // ""; contains("bee:approved-for-e2e")))' 2>/dev/null || echo "false")
+      fi
+
+      if [[ "$has_marker" == "true" ]]; then
+        # Valid escape hatch usage - proceed to e2e
+        decision="advance"
+        log "supervisor: detected valid self-authored escape hatch for PR #${pr_number}"
+      else
+        # Not a valid escape hatch - this is a divergence
+        decision="divergence"
+        should_dispatch=0
+        set_breeze_state "$REPO" "$pr_number" human
+
+        # File supervisor issue
+        local issue_body
+        issue_body=$(printf '%s\n' \
+          "**Supervisor: Reviewer verdict divergence detected**" \
+          "" \
+          "The supervisor detected a mismatch between the reviewer's activity marker and GitHub review state for PR #${pr_number}." \
+          "" \
+          "- **Activity marker action**: \`${marker_action:-"(none)"}\`" \
+          "- **GitHub review state**: \`${gh_state:-"(none)"}\`" \
+          "- **Expected**: These should align (approved/APPROVED, requested-changes/CHANGES_REQUESTED, or paused)" \
+          "" \
+          "This indicates the reviewer agent has diverged sources of truth for its verdict. Applied \`breeze:human\` label to PR #${pr_number} pending investigation." \
+          "" \
+          "See issue #734 for context on this invariant enforcement.")
+
+        gh issue create --repo "$REPO" \
+          --title "Supervisor: Reviewer verdict divergence on PR #${pr_number}" \
+          --body "$issue_body" 2>&1 | tee -a "$LOG" || true
+      fi
     elif [[ "$marker_action" == "paused" ]]; then
       decision="human"
       should_dispatch=0


### PR DESCRIPTION
**drafter:**

## Problem

The supervisor verdict check in `scripts/tick.sh` was incorrectly flagging PR #787 as having a divergence because it didn't recognize the self-authored PR escape hatch pattern. When a self-authored PR uses the escape hatch (posting a comment-style approval with the `bee:approved-for-e2e` marker), it legitimately has:
- `marker_action=approved` from the activity log
- `gh_state=COMMENTED` from GitHub's review state

## Solution  

Updated the supervisor verdict check to handle the self-authored escape hatch case:

1. When detecting `marker_action=approved` with `gh_state=COMMENTED`:
   - Check if the PR is self-authored (author matches current user)
   - Check for the `bee:approved-for-e2e` marker in reviews/comments
   - If both conditions are met, treat it as `decision=advance` to proceed to e2e
   - Otherwise, flag as divergence as before

2. The fix mirrors the logic from PR #787 but applies it to the supervisor check

This ensures the supervisor correctly recognizes legitimate escape hatch usage and doesn't create false positive divergence alerts.

## Testing

The existing supervisor verdict test (`tests/e2e/test-supervisor-verdict.sh`) continues to pass - it correctly tests the divergence detection for non-escape-hatch cases.

Fixes #788