### PR TITLE
fix: Handle self-authored escape hatch in nested supervisor verdict check

### DIFF
--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -582,6 +582,77 @@ pick_target() {
     # Check acceptable pairings
     if [[ "$marker_action" == "approved" ]] && [[ "$gh_state" == "APPROVED" ]]; then
       decision="advance"
+    elif [[ "$marker_action" == "approved" ]] && [[ "$gh_state" == "COMMENTED" ]]; then
+      # Check if this is a self-authored PR using the escape hatch (issue #791)
+      # In this case, marker_action=approved with gh_state=COMMENTED is legitimate
+      local pr_author=""
+      pr_author=$(gh pr view "$pr_number" --repo "$REPO" --json author --jq '.author.login' 2>/dev/null || echo "")
+
+      local current_user=""
+      current_user=$(gh api user --jq '.login' 2>/dev/null || echo "")
+
+      # Check if PR is self-authored and has the escape hatch marker
+      if [[ "$pr_author" == "$current_user" ]] && [[ -n "$pr_author" ]]; then
+        # Check for bee:approved-for-e2e marker in reviews or comments
+        local has_escape_hatch=""
+        has_escape_hatch=$(gh pr view "$pr_number" --repo "$REPO" --json reviews,comments --jq '
+          (any(.reviews[]?.body // ""; contains("<!-- bee:approved-for-e2e -->"))) or
+          (any(.comments[]?.body // ""; contains("<!-- bee:approved-for-e2e -->")))
+        ' 2>/dev/null || echo "false")
+
+        if [[ "$has_escape_hatch" == "true" ]]; then
+          # This is a legitimate escape hatch usage - proceed to e2e
+          decision="advance"
+        else
+          # Self-authored but no escape hatch - this is a divergence
+          decision="divergence"
+          should_dispatch=0
+          set_breeze_state "$REPO" "$pr_number" human
+
+          # File supervisor issue
+          local issue_body
+          issue_body=$(printf '%s\n' \
+            "**Supervisor: Reviewer verdict divergence detected**" \
+            "" \
+            "The supervisor detected a mismatch between the reviewer's activity marker and GitHub review state for PR #${pr_number}." \
+            "" \
+            "- **Activity marker action**: \`${marker_action:-"(none)"}\`" \
+            "- **GitHub review state**: \`${gh_state:-"(none)"}\`" \
+            "- **Expected**: These should align (approved/APPROVED, requested-changes/CHANGES_REQUESTED, or paused)" \
+            "" \
+            "This indicates the reviewer agent has diverged sources of truth for its verdict. Applied \`breeze:human\` label to PR #${pr_number} pending investigation." \
+            "" \
+            "See issue #734 for context on this invariant enforcement.")
+
+          gh issue create --repo "$REPO" \
+            --title "Supervisor: Reviewer verdict divergence on PR #${pr_number}" \
+            --body "$issue_body" 2>&1 | tee -a "$LOG" || true
+        fi
+      else
+        # Not self-authored, so COMMENTED with approved is a divergence
+        decision="divergence"
+        should_dispatch=0
+        set_breeze_state "$REPO" "$pr_number" human
+
+        # File supervisor issue
+        local issue_body
+        issue_body=$(printf '%s\n' \
+          "**Supervisor: Reviewer verdict divergence detected**" \
+          "" \
+          "The supervisor detected a mismatch between the reviewer's activity marker and GitHub review state for PR #${pr_number}." \
+          "" \
+          "- **Activity marker action**: \`${marker_action:-"(none)"}\`" \
+          "- **GitHub review state**: \`${gh_state:-"(none)"}\`" \
+          "- **Expected**: These should align (approved/APPROVED, requested-changes/CHANGES_REQUESTED, or paused)" \
+          "" \
+          "This indicates the reviewer agent has diverged sources of truth for its verdict. Applied \`breeze:human\` label to PR #${pr_number} pending investigation." \
+          "" \
+          "See issue #734 for context on this invariant enforcement.")
+
+        gh issue create --repo "$REPO" \
+          --title "Supervisor: Reviewer verdict divergence on PR #${pr_number}" \
+          --body "$issue_body" 2>&1 | tee -a "$LOG" || true
+      fi
     elif [[ "$marker_action" == "paused" ]]; then
       decision="human"
       should_dispatch=0


### PR DESCRIPTION
**drafter:**

## Problem

The supervisor verdict check was creating false positive divergence alerts for legitimate self-authored PRs using the escape hatch pattern, as seen with PR #791. When a self-authored PR uses the escape hatch (posting a comment-style approval with the `bee:approved-for-e2e` marker), it legitimately has:
- `marker_action=approved` from the activity log
- `gh_state=COMMENTED` from GitHub's review state

This caused cascading false positives where PRs that were themselves fixing the escape hatch handling would trigger divergence alerts.

## Solution

Updated the supervisor verdict check in `scripts/tick.sh` to handle the self-authored escape hatch case:

1. When detecting `marker_action=approved` with `gh_state=COMMENTED`:
   - Check if the PR is self-authored (author matches current user)
   - Check for the `bee:approved-for-e2e` marker in reviews/comments
   - If both conditions are met, treat it as `decision=advance` to proceed to e2e
   - Otherwise, flag as divergence as before

2. This prevents false positive divergence alerts while still catching genuine verdict mismatches

## Testing

The existing supervisor verdict test (`tests/e2e/test-supervisor-verdict.sh`) continues to pass - it correctly tests the divergence detection for non-escape-hatch cases. The escape hatch detection is an additional condition that doesn't break existing functionality.

Fixes #792