### PR TITLE
docs: refresh README and AGENTS.md to reflect current system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,35 +4,85 @@ Ported from breeze (`first-tree/src/products/breeze`). All agents MUST follow.
 
 ## Label state machine
 
-Four labels, mutually exclusive. Precedence: **done > MERGED/CLOSED > human > wip > absent**.
+Four canonical labels plus one quarantine label. Mutually exclusive among the canonical four. Precedence: **done > MERGED/CLOSED > human > wip > absent**.
 
 | Label | Meaning | Applied by |
 | --- | --- | --- |
-| `breeze:new` | Default. Absence of all `breeze:*` labels is the real "new" signal. | Human-readable only — never auto-applied. |
-| `breeze:wip` | An agent is actively working this item. | `claim.sh` on acquire; drafter when opening a PR. |
-| `breeze:human` | Needs human judgment. Tick dispatcher skips this. | Any agent via `bee pause`, supervisor `design-conflicting`, merger when stuck. |
-| `breeze:done` | Agent has finished. GitHub MERGED/CLOSED also implies done. | Rarely set explicitly — prefer closing the issue/PR. |
+| `breeze:new` | Visual marker only. Absence of all `breeze:*` labels is the real "new" signal. | Human, optionally. Never auto-applied. |
+| `breeze:wip` | An agent is actively working this item. | `claim.sh` on acquire. |
+| `breeze:human` | Needs human judgment. Tick dispatcher skips this. | Any agent via `bee pause`; supervisor on `design-conflicting`; merger when stuck. |
+| `breeze:done` | Agent has finished. GitHub MERGED/CLOSED also implies done. | Merger on merge, auditor on close, janitor on drift cleanup. |
+| `breeze:quarantine-hotloop` | A hot-loop was detected on this PR; dispatcher skips. | Tick's hot-loop detector (see `check_hot_loop` in `tick.sh`). |
 
 ### Rules
 
 - **Use the helper.** All transitions go through `set_breeze_state <repo> <num> <state>` in `scripts/labels.sh`, which atomically removes prior `breeze:*` labels. Never call `gh edit --add-label breeze:*` directly.
-- **Exactly one.** At any moment a non-closed item has zero or one `breeze:*` label. Two is a bug.
-- **Agent claims = `breeze:wip`.** `claim_acquire` in `scripts/claim.sh` already does this for issues; drafter must also set `breeze:wip` on PRs it opens.
+- **Exactly one canonical label.** At any moment a non-closed item has zero or one of {`wip`, `human`, `done`}. `quarantine-hotloop` may coexist with another canonical label.
+- **Do NOT label PRs you open.** Drafter leaves opened PRs unlabeled so the dispatcher can route them. `claim_acquire` handles `breeze:wip` on issues only.
 - **No other label namespaces.** Do NOT apply `source:*` or `priority:*` labels on issues or PRs. Source is internal (task kind). Priority is a dispatcher concern — if you need it, sort in `tick.sh`, don't label.
-- **`breeze:done` is rarely needed.** Closing the issue/PR is enough (GitHub's state derives done). Only set `breeze:done` explicitly when the agent has finished its part but the item stays open for downstream work.
+- **`breeze:done` on merge/close.** Merger sets it after squash-merge; auditor sets it before closing an umbrella issue. The janitor (`janitor_label_cleanup` in `tick.sh`) fixes drift from any agent that forgot.
+
+## Escape hatches (single-account mode)
+
+Because git-bee runs all agents + human as the same GitHub account (#754), GitHub blocks formal self-approval and self-request-changes. Two HTML markers replace those actions:
+
+| Marker | Posted by | Effect |
+| --- | --- | --- |
+| `<!-- bee:approved-for-e2e -->` | Human, in a PR comment or review at/after HEAD SHA | Dispatcher treats the PR as approved; advances to e2e/merger. |
+| `<!-- bee:changes-requested -->` | Human, in a PR comment at/after HEAD SHA | Dispatcher routes the PR to drafter for revision on next tick. |
+
+Use the `bee` CLI:
+
+```bash
+bee request-changes <pr> [reason]   # posts the revision marker, removes breeze:human
+bee pause <pr> "<reason>"           # applies breeze:human, posts comment, releases claim
+```
+
+## Agent roster
+
+| Agent | Job |
+| --- | --- |
+| `drafter` | Reads design-doc issues, drafts milestone plans, opens implementation PRs, addresses reviewer feedback. |
+| `planner` | Breaks thin design-doc issues into milestone plans before drafter starts implementing. |
+| `reviewer` | Reviews implementation PRs. Three-state verdict invariant: approve / request-changes / escalate. |
+| `e2e` | Runs a PR's `tests/e2e/verify.sh` in a sandbox; posts the canonical `**E2E trace (pass\|fail)**` comment. |
+| `e2e-designer` | Writes e2e test cases when a PR lacks one. |
+| `e2e-supervisor` | Classifies e2e failures (lazy-run, code-bug, test-bug, design-trivial, design-conflicting). |
+| `merger` | Squash-merges approved PRs with passing e2e, transitions to `breeze:done`, closes linked issues. |
+| `auditor` | Audits multi-PR design-doc coverage, closes umbrella issues when all PRs are merged. |
 
 ## Comment prefixes
 
 Every PR/issue comment an agent posts must start with `**<role>:**` on its own first line:
 
 - `**drafter:**`, `**reviewer:**`, `**e2e:**`, `**e2e-designer:**`, `**e2e-supervisor:**`, `**planner:**`, `**auditor:**`, `**merger:**`
+- Human comments posted through `bee` use `**human:**`.
 
-The canonical E2E trace comment (`**E2E trace (pass|fail)**`) emitted by `scripts/e2e-sandbox.sh finalize` is exempt — it identifies itself.
+The canonical e2e trace comment (`**E2E trace (pass|fail)**`) emitted by `scripts/e2e-sandbox.sh finalize` is exempt — it identifies itself.
+
+## Status-line contract
+
+Every agent ends its stdout with one line matching:
+
+```
+<role>: target=<n> action=<action> next=<role|none>
+```
+
+`tick.sh` parses this to populate `activity.ndjson` and to drive next-role hints. Acceptable field names: `action=`, `result=`, `verdict=`. If none is present, the tick treats it as a null outcome and writes a failure file.
 
 ## Claims
 
-Claim acquisition is label-based today (via `breeze:wip`) with a freshness comment marker. This differs from breeze (filesystem lockfiles) and is acceptable while git-bee is single-machine. See `scripts/claim.sh`.
+Claim acquisition is label-based (via `breeze:wip`) plus a freshness comment marker (`<!-- breeze:claimed-at=<ISO8601> by=<agent-id> -->`). A claim is stale once the labeled-event timestamp is older than `CLAIM_TTL_SECONDS` (default 7200 = 2h). Any agent may take over a stale claim.
+
+See `scripts/claim.sh` for `claim_acquire` / `claim_release` / `claim_check`.
 
 ## When blocked
 
 Any agent that gets stuck must call `bee pause <n> "<reason>"`. That applies `breeze:human`, posts a comment, and releases the claim.
+
+## Safety mechanisms
+
+- **PID lock** (`/tmp/git-bee-agent.pid`) prevents concurrent agents on the same machine. Tick exits `lock-held` if set.
+- **3-consecutive-crash rollback**: if three ticks in a row exit non-zero, tick.sh rolls back to the last known-good SHA, writes `~/.git-bee/ROLLBACK`, and files an alert issue. The marker gates further ticks until removed.
+- **Hot-loop quarantine**: if an agent is dispatched on the same target twice within 5 minutes with `outcome=null`, the PR gets `breeze:quarantine-hotloop` and a bug issue is filed. Quarantine auto-releases when new commits land on the PR.
+- **Pre-push guard**: `scripts/preflight-push.sh` hard-refuses pushes whose target ref is `main` or `master`. Source it before any `git push` in agent Bash tool calls.

--- a/README.md
+++ b/README.md
@@ -86,37 +86,48 @@ An autonomous agent that buzzes through GitHub issues on a schedule, picks up un
 6. The agent works the item to completion, then removes its claim.
 7. When nothing is left open, the tick exits quietly. The project is finalized.
 
-## Approving PRs
+## Single-account mode
 
-git-bee is a **one-account** system — all agents run as your GitHub account. This design choice eliminates onboarding friction (no second GitHub account required) but means GitHub's self-approval restriction applies.
+git-bee is a **one-account** system — all agents run as your GitHub account. This eliminates onboarding friction (no second GitHub account required) but means GitHub's self-review restrictions apply: you can't formally approve or request-changes on your own PR. Two HTML markers replace those actions.
 
-To approve a git-bee PR for E2E testing and merging:
-- Post a comment containing `<!-- bee:approved-for-e2e -->` on the PR
-- The marker must be posted at or after the current HEAD commit timestamp to be valid
-- Removing `breeze:human` is optional — the dispatcher respects the marker regardless
-- Once approved, the PR advances through E2E testing and merging without further pauses (unless new commits are pushed)
+### Approving a PR
+
+Post a comment on the PR containing `<!-- bee:approved-for-e2e -->`. The marker must be at or after the current HEAD commit timestamp. The dispatcher advances the PR through E2E testing and merging without further pauses (unless new commits are pushed).
+
+### Requesting changes on a PR
+
+Use `bee request-changes <pr> [reason]` (or post a comment with `<!-- bee:changes-requested -->` manually). The dispatcher routes the PR to drafter for revision on the next tick.
 
 ## Labels
 
-Only three, matching the breeze/gardener convention. No `breeze:new` — absence of any label on an open item means "unclaimed, fair game."
+Four canonical labels plus one quarantine label. See `AGENTS.md` for the full state machine.
 
 | Label | Meaning | Who sets |
 |---|---|---|
-| `breeze:wip` | An agent has claimed this item | The claiming agent |
-| `breeze:done` | All work for this item is complete | The agent, when closing |
-| `breeze:human` | Agent gave up after N attempts, needs human | The responder agent, per breeze#12 convention (N=5) |
+| `breeze:wip` | An agent has claimed this item | `claim_acquire` |
+| `breeze:human` | Agent needs human judgment | Any agent via `bee pause` |
+| `breeze:done` | All work complete | Merger, auditor, janitor |
+| `breeze:quarantine-hotloop` | Hot-loop detected; dispatcher skips | Tick's hot-loop detector |
 
-Stale `breeze:wip` = labeled event timestamp older than 2 hours. Any agent may take over a stale claim.
-
-To prevent label churn, `breeze:wip` is kept when agents hand off work. The next agent refreshes the claim without removing/re-adding the label.
+Stale `breeze:wip` = labeled-event timestamp older than 2 hours. Any agent may take over a stale claim. The `breeze:done` transition happens automatically on merge/close via merger and a periodic janitor sweep.
 
 ## Agent roles
 
 - [`agents/drafter.md`](agents/drafter.md) — Reads a design-doc issue, drafts the design in comments, opens implementation PRs linked with `Fixes #<issue>`. Also addresses reviewer feedback.
-- [`agents/reviewer.md`](agents/reviewer.md) — Reviews implementation PRs. Normal prose review comments. Focus: does the code match the design, security, obvious implementation issues.
+- [`agents/planner.md`](agents/planner.md) — Breaks thin design-doc issues into a milestone plan before drafter implements.
+- [`agents/reviewer.md`](agents/reviewer.md) — Reviews implementation PRs with a three-state verdict: approve / request-changes / escalate.
 - [`agents/e2e.md`](agents/e2e.md) — Runs E2E for a PR in a sandbox repo. Commits each step as its own commit; the Git log is the test trace.
-- [`agents/merger.md`](agents/merger.md) — Merges approved PRs with passing E2E; closes linked issues with `breeze:done`.
-- [`agents/auditor.md`](agents/auditor.md) — Fresh-context audit of multi-PR design-doc coverage. Runs when every PR in a doc's `## Milestone plan` is merged; closes the umbrella only if all coverage checks pass, else labels `breeze:human`.
+- [`agents/e2e-designer.md`](agents/e2e-designer.md) — Writes e2e test cases for PRs that lack one.
+- [`agents/e2e-supervisor.md`](agents/e2e-supervisor.md) — Classifies e2e failures (lazy-run, code-bug, test-bug, design-trivial, design-conflicting).
+- [`agents/merger.md`](agents/merger.md) — Squash-merges approved PRs with passing E2E; transitions to `breeze:done`, closes linked issues.
+- [`agents/auditor.md`](agents/auditor.md) — Fresh-context audit of multi-PR design-doc coverage. Closes the umbrella only if all coverage checks pass, else labels `breeze:human`.
+
+## Safety mechanisms
+
+- **PID lock** (`/tmp/git-bee-agent.pid`) prevents concurrent agents on the same machine.
+- **3-crash rollback**: three consecutive non-zero ticks roll back to the last known-good SHA and pause the loop via `~/.git-bee/ROLLBACK`.
+- **Hot-loop quarantine**: dispatching the same agent on the same target twice within 5 minutes with `outcome=null` quarantines the PR and files a bug.
+- **Pre-push guard**: `scripts/preflight-push.sh` refuses pushes targeting `main` or `master`.
 
 ## Setup
 


### PR DESCRIPTION
**human:**

No code changes — docs only. Both files had drifted significantly from what actually ships.

## README.md
- Replace 'Approving PRs' with 'Single-account mode' covering both escape hatches (the existing `bee:approved-for-e2e` AND the new `bee:changes-requested` from #784).
- Update labels table to include `breeze:quarantine-hotloop` (from #779).
- Expand agent roster from 5 to 8 (add `planner`, `e2e-designer`, `e2e-supervisor` which existed in `agents/` but weren't documented).
- Add **Safety mechanisms** section (PID lock, rollback, hot-loop quarantine, pre-push guard).

## AGENTS.md
- Correct label state machine to include `breeze:quarantine-hotloop`.
- Fix a factual error: said 'drafter sets `breeze:wip` on PRs it opens', but `agents/drafter.md` explicitly says the opposite ('Do NOT label PRs you open').
- Clarify `breeze:done` is NOT rare — it's set automatically by merger, auditor, and the janitor cleanup sweep from #785.
- Add **Escape hatches** section documenting both HTML markers and the `bee` CLI.
- Document the **status-line contract** (`action=` / `result=` / `verdict=`) that `tick.sh` parses from agent stdout.
- Add **Safety mechanisms** section.