### PR TITLE
phase1a: delegate breeze label inventory to first-tree (refs #31)

### DIFF
--- a/scripts/ensure-labels.sh
+++ b/scripts/ensure-labels.sh
@@ -1,34 +1,52 @@
 #!/usr/bin/env bash
-# Ensure all four breeze labels exist with canonical colors/descriptions.
+# Ensure all breeze labels exist with canonical colors/descriptions.
 # Idempotent — safe to run multiple times.
 #
-# Per first-tree's src/products/breeze/engine/runtime/types.ts:
-#   breeze:new    — 0075ca — "Breeze: new notification"
-#   breeze:wip    — e4e669 — "Breeze: work in progress"
-#   breeze:human  — d93f0b — "Breeze: needs human attention"
-#   breeze:done   — 0e8a16 — "Breeze: handled"
+# Phase 1a of migration to first-tree breeze (#31): delegate the
+# breeze:* label inventory to `first-tree breeze status-manager
+# ensure-labels` so the colors, descriptions, and list are sourced
+# from breeze's `BREEZE_LABEL_META` (single source of truth). Fall
+# back to the inline list if first-tree is not on PATH so the tick
+# loop keeps working on machines that haven't installed first-tree.
+#
+# The git-bee-only `breeze:quarantine-hotloop` label (from #779) is
+# still created by this script — breeze does not know about it.
 
 set -euo pipefail
 
 REPO="${1:-serenakeyitan/git-bee}"
 
-# Define labels: name|color|description
-declare -a LABELS=(
-  "breeze:new|0075ca|Breeze: new notification"
-  "breeze:wip|e4e669|Breeze: work in progress"
-  "breeze:human|d93f0b|Breeze: needs human attention"
-  "breeze:done|0e8a16|Breeze: handled"
+# Delegate breeze canonical labels (breeze:new|wip|human|done) to first-tree
+# if available. Errors are swallowed and we continue to the fallback so a
+# missing or misbehaving first-tree never blocks the tick loop.
+if command -v first-tree >/dev/null 2>&1; then
+  if first-tree breeze status-manager ensure-labels "$REPO" >/dev/null 2>&1; then
+    DELEGATED=1
+  fi
+fi
+
+# Fallback list — used when first-tree is not on PATH OR when the delegation
+# call above failed. Also always applied for git-bee-only labels (quarantine).
+declare -a LABELS=()
+if [[ "${DELEGATED:-0}" != "1" ]]; then
+  LABELS+=(
+    "breeze:new|0075ca|Breeze: new notification"
+    "breeze:wip|e4e669|Breeze: work in progress"
+    "breeze:human|d93f0b|Breeze: needs human attention"
+    "breeze:done|0e8a16|Breeze: handled"
+  )
+fi
+
+# git-bee extension — not part of breeze canonical spec. Always created here.
+LABELS+=(
+  "breeze:quarantine-hotloop|fbca04|Bee: hot-loop detected; dispatcher skipping"
 )
 
 for label_spec in "${LABELS[@]}"; do
   IFS='|' read -r name color desc <<< "$label_spec"
-
-  # Check if label exists
   if gh label list --repo "$REPO" --limit 200 | grep -q "^${name}\b"; then
-    # Update existing label (color and description may have changed)
     gh label edit "$name" --repo "$REPO" --color "$color" --description "$desc" >/dev/null 2>&1 || true
   else
-    # Create new label
     gh label create "$name" --repo "$REPO" --color "$color" --description "$desc" >/dev/null 2>&1 || true
   fi
 done


### PR DESCRIPTION
**human:**

Part 1 of the breeze migration scoped on #31.

## Change

`scripts/ensure-labels.sh` now delegates the breeze canonical labels (new/wip/human/done) to `first-tree breeze status-manager ensure-labels`. Single source of truth for colors and descriptions is now breeze's `BREEZE_LABEL_META` TypeScript constant, shared with other first-tree products.

Fallback to an inline list if:
- `first-tree` not on PATH, OR
- the delegation call exits non-zero

so the tick loop keeps working on any machine.

The git-bee extension label `breeze:quarantine-hotloop` (#779) is still created by this script — not part of breeze's canonical four.

## Verified

Ran locally against serenakeyitan/git-bee. All 5 labels present with correct colors:

```
breeze:wip                     #e4e669
breeze:done                    #0e8a16
breeze:human                   #d93f0b
breeze:new                     #0075ca
breeze:quarantine-hotloop      #fbca04
```

## What's NOT in this PR

Label *transitions* (the `set_breeze_state` helper in `scripts/labels.sh`) still live in git-bee. Reason: `first-tree breeze status-manager set` requires the item to be in breeze's local inbox (`~/.breeze/inbox.json`), which breeze only populates from GitHub notifications. Git-bee's PR-state model doesn't map cleanly to breeze's notification model.

That structural gap is the Phase 2 problem — see the gap analysis comment on #31 and upcoming Phase-2-prep PR.

Refs #31.