### PR TITLE
feat(supervisor): add deduplication for divergence issues

### DIFF
--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -685,7 +685,80 @@ pick_target() {
         should_dispatch=0
         set_breeze_state "$REPO" "$pr_number" human
 
-        # File supervisor issue
+        # Check if a supervisor divergence issue already exists for this PR
+        local existing_issue
+        existing_issue=$(gh issue list --repo "$REPO" --state open \
+          --search "Supervisor: Reviewer verdict divergence on PR #${pr_number} in:title" \
+          --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+        if [[ -n "$existing_issue" ]]; then
+          # Update existing issue with new occurrence
+          local update_comment="**Divergence detected again**
+
+Time: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+- **Activity marker action**: \`${marker_action:-"(none)"}\`
+- **GitHub review state**: \`${gh_state:-"(none)"}\`
+- **Expected**: These should align (approved/APPROVED, requested-changes/CHANGES_REQUESTED, or paused)
+
+The \`breeze:human\` label remains on PR #${pr_number}."
+
+          gh issue comment "$existing_issue" --repo "$REPO" --body "$update_comment" 2>&1 | tee -a "$LOG" || true
+          log "updated existing supervisor divergence issue #$existing_issue with new occurrence"
+        else
+          # File new supervisor issue
+          local issue_body
+          issue_body=$(printf '%s\n' \
+            "**Supervisor: Reviewer verdict divergence detected**" \
+            "" \
+            "The supervisor detected a mismatch between the reviewer's activity marker and GitHub review state for PR #${pr_number}." \
+            "" \
+            "- **Activity marker action**: \`${marker_action:-"(none)"}\`" \
+            "- **GitHub review state**: \`${gh_state:-"(none)"}\`" \
+            "- **Expected**: These should align (approved/APPROVED, requested-changes/CHANGES_REQUESTED, or paused)" \
+            "" \
+            "This indicates the reviewer agent has diverged sources of truth for its verdict. Applied \`breeze:human\` label to PR #${pr_number} pending investigation." \
+            "" \
+            "See issue #734 for context on this invariant enforcement.")
+
+          gh issue create --repo "$REPO" \
+            --title "Supervisor: Reviewer verdict divergence on PR #${pr_number}" \
+            --body "$issue_body" 2>&1 | tee -a "$LOG" || true
+        fi
+      fi
+    elif [[ "$marker_action" == "paused" ]]; then
+      decision="human"
+      should_dispatch=0
+      # breeze:human should already be set, but ensure it
+      set_breeze_state "$REPO" "$pr_number" human
+    else
+      # Divergence detected - flag for human review
+      decision="divergence"
+      should_dispatch=0
+      set_breeze_state "$REPO" "$pr_number" human
+
+      # Check if a supervisor divergence issue already exists for this PR
+      local existing_issue
+      existing_issue=$(gh issue list --repo "$REPO" --state open \
+        --search "Supervisor: Reviewer verdict divergence on PR #${pr_number} in:title" \
+        --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+      if [[ -n "$existing_issue" ]]; then
+        # Update existing issue with new occurrence
+        local update_comment="**Divergence detected again**
+
+Time: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+- **Activity marker action**: \`${marker_action:-"(none)"}\`
+- **GitHub review state**: \`${gh_state:-"(none)"}\`
+- **Expected**: These should align (approved/APPROVED, requested-changes/CHANGES_REQUESTED, or paused)
+
+The \`breeze:human\` label remains on PR #${pr_number}."
+
+        gh issue comment "$existing_issue" --repo "$REPO" --body "$update_comment" 2>&1 | tee -a "$LOG" || true
+        log "updated existing supervisor divergence issue #$existing_issue with new occurrence"
+      else
+        # File new supervisor issue
         local issue_body
         issue_body=$(printf '%s\n' \
           "**Supervisor: Reviewer verdict divergence detected**" \
@@ -704,35 +777,6 @@ pick_target() {
           --title "Supervisor: Reviewer verdict divergence on PR #${pr_number}" \
           --body "$issue_body" 2>&1 | tee -a "$LOG" || true
       fi
-    elif [[ "$marker_action" == "paused" ]]; then
-      decision="human"
-      should_dispatch=0
-      # breeze:human should already be set, but ensure it
-      set_breeze_state "$REPO" "$pr_number" human
-    else
-      # Divergence detected - flag for human review
-      decision="divergence"
-      should_dispatch=0
-      set_breeze_state "$REPO" "$pr_number" human
-
-      # File supervisor issue
-      local issue_body
-      issue_body=$(printf '%s\n' \
-        "**Supervisor: Reviewer verdict divergence detected**" \
-        "" \
-        "The supervisor detected a mismatch between the reviewer's activity marker and GitHub review state for PR #${pr_number}." \
-        "" \
-        "- **Activity marker action**: \`${marker_action:-"(none)"}\`" \
-        "- **GitHub review state**: \`${gh_state:-"(none)"}\`" \
-        "- **Expected**: These should align (approved/APPROVED, requested-changes/CHANGES_REQUESTED, or paused)" \
-        "" \
-        "This indicates the reviewer agent has diverged sources of truth for its verdict. Applied \`breeze:human\` label to PR #${pr_number} pending investigation." \
-        "" \
-        "See issue #734 for context on this invariant enforcement.")
-
-      gh issue create --repo "$REPO" \
-        --title "Supervisor: Reviewer verdict divergence on PR #${pr_number}" \
-        --body "$issue_body" 2>&1 | tee -a "$LOG" || true
     fi
 
     # Log supervisor decision


### PR DESCRIPTION
**drafter:**

## Summary
Before filing a new "Supervisor: Reviewer verdict divergence on PR #N" issue, check if an open issue already exists with that title. If yes, comment on the existing issue instead of creating a new one.

## Changes
- Modified `scripts/tick.sh` to add deduplication logic in both locations where supervisor files divergence issues
- Pattern matches the existing hot-loop issue deduplication approach:
  1. Check for existing open issue with the same title
  2. If found, add a comment with new occurrence details
  3. If not found, create a new issue as before

## Problem Addressed
Prevents cascading issue creation when the same divergence is detected multiple times, as happened with PR #785 → fix PR #787 → supervisor flagged THAT too → PR #791 → supervisor flagged THAT too → PR #793. Three PRs for the same bug with no duplicate detection.

## Testing
- Ran `tests/e2e/test-supervisor-verdict.sh` successfully
- Supervisor verdict detection logic remains intact
- Only the issue filing behavior is modified to prevent duplicates

Refs #798 (v0.2.0 roadmap M1/PR 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)