### PR TITLE
fix(tick): remove stray bare 'status_line' lines (cleanup)

### DIFF
--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -1449,7 +1449,6 @@ else
       # Parse agent's stdout for outcome and next hint
       agent_outcome="" agent_next=""
       if [[ -f "$output_file" ]]; then
-        status_line
         status_line=$(grep -E "^${kind}:" "$output_file" | tail -1 || echo "")
         if [[ -n "$status_line" ]]; then
           # Parse outcome field (could be action=, result=, or verdict=)
@@ -1499,7 +1498,6 @@ else
       # Parse agent's stdout for outcome and next hint
       agent_outcome="" agent_next=""
       if [[ -f "$output_file" ]]; then
-        status_line
         status_line=$(grep -E "^${kind}:" "$output_file" | tail -1 || echo "")
         if [[ -n "$status_line" ]]; then
           # Parse outcome field (could be action=, result=, or verdict=)


### PR DESCRIPTION
**human:**

Two-line cleanup. Caught by manual smoke-testing after #810.

Lines 1452 and 1502 each had a bare `status_line` statement that bash tried to execute as a command — leftover from the top-level-local fix cascade earlier today.

Zero functional impact (variable gets assigned in the next statement anyway), but the noise in the log made it harder to spot real problems.