### PR TITLE
fix: gate-check now treats no Finalization gate section as gate open

### DIFF
--- a/agents/planner.md
+++ b/agents/planner.md
@@ -14,6 +14,8 @@ If the environment variable `GIT_BEE_LAST_FAILURE` is set, read the file at that
 
 Read finalized design-doc issues and create structured milestone plans that break the work into appropriately-sized PRs.
 
+**Skip rule:** If the issue title starts with `bug:`, `fix:`, or contains `regression`, exit with status `planner: issue=<n> action=skipped-bug-report next=none`. Bug reports don't need milestone plans.
+
 1. Read the issue body and all comments to understand the full design.
 2. Identify logical boundaries for splitting the work into separate PRs.
 3. Apply the size rule: each PR should be 100-500 lines of diff. Smaller → combine. Larger → split.
@@ -62,7 +64,7 @@ If the design is unclear or contradictory:
 
 ## Output
 
-End with: `planner: issue=<n> action=<planned|escalated-too-many-prs|gave-up-breeze-human> next=<role|none>`.
+End with: `planner: issue=<n> action=<planned|escalated-too-many-prs|gave-up-breeze-human|skipped-bug-report> next=<role|none>`.
 
 Next-role hints:
 - After planning: `next=e2e-designer`

--- a/scripts/gate-check.sh
+++ b/scripts/gate-check.sh
@@ -4,13 +4,13 @@
 # Usage: gate-check.sh <owner/repo> <issue-number>
 #
 # Exit codes:
-#   0  gate open — last body edit (or original authorship) is by the repo owner
-#      AND the first checkbox under `## Finalization gate` is `[x]`. Dispatch ok.
+#   0  gate open — EITHER (a) no `## Finalization gate` section (most issues), OR
+#      (b) has the section AND last body edit is by the repo owner AND the first
+#      checkbox under `## Finalization gate` is `[x]`. Dispatch ok.
 #   1  gate closed — checkbox unchecked, or body unreadable. Fail closed.
 #   2  gate ticked by non-owner — checkbox is `[x]` but the latest body author
 #      is not the repo owner. Bot-authored ticks don't count.
-#   3  not a design-doc issue — no `## Finalization gate` section. Caller
-#      decides policy (tick.sh treats this as "gate not applicable").
+#   3  (deprecated — now returns 0) previously indicated no gate section.
 #
 # Why GraphQL: GitHub's REST timeline API does not emit events for issue body
 # edits. `userContentEdits` on the issue node does — newest first.
@@ -43,7 +43,9 @@ gate_line=$(awk '
 ' <<<"$body")
 
 if ! grep -qE '^## Finalization gate[[:space:]]*$' <<<"$body"; then
-  exit 3
+  # No Finalization gate section: treat as gate open by default (rc=0)
+  # This allows Phase 2 routing to apply to issues without the formal header
+  exit 0
 fi
 
 if [[ -z "$gate_line" ]]; then


### PR DESCRIPTION
**drafter:**

This PR implements the prerequisite fix for the v0.2.0 role simplification.

## Summary

Changes `gate-check.sh` so rc=3 (no Finalization gate section) maps to rc=0 (gate open). This unblocks Phase 2 routing for all issues without the formal header, allowing planner/auditor/e2e-designer/e2e-supervisor to finally dispatch.

Also adds a skip rule to planner.md to exit early on bug reports (titles starting with `bug:`, `fix:`, or containing `regression`), preventing unnecessary milestone planning on simple bug fixes.

## Changes

- `scripts/gate-check.sh`: Return 0 instead of 3 when no Finalization gate section exists
- `agents/planner.md`: Add skip rule for bug reports

## Testing

Manually tested:
- `./scripts/gate-check.sh serenakeyitan/git-bee 817` now returns 0 (was 3)
- `./scripts/gate-check.sh serenakeyitan/git-bee 820` returns 0

Fixes #817
Refs #820

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>