### PR TITLE
fix(dispatcher): recognize reviewer verdicts in single-account mode

### DIFF
--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -610,6 +610,26 @@ pr_pipeline_position() {
     return
   fi
 
+  # Check for reviewer verdict in COMMENTED reviews at HEAD (single-account mode)
+  # Reviewer posts "**reviewer verdict: approved**" or "**reviewer verdict: changes-requested**"
+  local reviewer_verdict_at_head
+  reviewer_verdict_at_head=$(echo "$pr_json" | jq -r --arg sha "$pr_sha"     '[.reviews[]? | select(.commit.oid == $sha and .state == "COMMENTED" and (.body | startswith("**reviewer verdict:")))] | if length > 0 then .[0].body | split("\n")[0] | split(": ")[1] | rtrimstr("**") else empty end' 2>/dev/null || echo "")
+
+  if [[ "$reviewer_verdict_at_head" == "approved" ]]; then
+    # Reviewer approved in single-account mode, treat as approved for e2e
+    if [[ "$e2e_pass_at_head" == "true" ]]; then
+      echo "ready-to-merge"
+    elif [[ "$e2e_fail_at_head" == "true" ]]; then
+      echo "approved-e2e-failed"
+    else
+      echo "approved-e2e-stale"
+    fi
+    return
+  elif [[ "$reviewer_verdict_at_head" == "changes-requested" ]]; then
+    echo "needs-drafter-review"
+    return
+  fi
+
   # Reviewed-but-not-approved-not-changes-requested at HEAD. In single-account
   # mode this is the common case: all reviews are COMMENTED (can't self-approve).
   # If reviewer has already looked at HEAD, do NOT re-dispatch reviewer — the


### PR DESCRIPTION
**drafter:**

This PR fixes the dispatcher blind spot that was causing the idle-with-debt watchdog to trigger.

## Problem

The dispatcher had a routing blind spot where 6 PRs were sitting idle despite having reviewer verdicts. The issue was reported by the watchdog in #826.

## Root Cause

In single-account mode, the reviewer posts verdicts like `**reviewer verdict: approved**` or `**reviewer verdict: changes-requested**` as COMMENTED reviews (since it can't self-approve). However, the dispatcher's `pr_pipeline_position` function was only checking for HTML comment markers like `<!-- bee:approved-for-e2e -->` which the reviewer doesn't post.

When reviews existed at HEAD but no markers were found, the dispatcher returned "skip", leaving PRs in limbo.

## Solution

Updated `pr_pipeline_position` in `scripts/tick.sh` to:
1. Parse reviewer verdicts from the review body text
2. Route "approved" verdicts to e2e (as `approved-e2e-stale`)
3. Route "changes-requested" verdicts back to drafter (as `needs-drafter-review`)

This aligns with the documented reviewer behavior in `agents/reviewer.md`.

## Testing

- Verified that reviewer verdicts are correctly extracted from review bodies
- Confirmed that all 6 stuck PRs would now be routed correctly:
  - PR #825: changes-requested → needs-drafter-review → drafter
  - PRs #824, #823, #822, #818, #812: approved → approved-e2e-stale → e2e

Fixes #826