### PR TITLE
fix(tick): delete stray 'status_line' line (recurrence of #811 introduced by #825)

### DIFF
--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -1534,7 +1534,6 @@ else
     # Parse agent's stdout for successful test run
     agent_outcome="" agent_next=""
     if [[ -f "$output_file" ]]; then
-      status_line
       status_line=$(grep -E "^${kind}:" "$output_file" | tail -1 || echo "")
       if [[ -n "$status_line" ]]; then
         # Parse outcome field (could be action=, result=, or verdict=)


### PR DESCRIPTION
**human:**

#825 re-introduced the same bug #811 fixed yesterday. Line 1537 of tick.sh has a bare `status_line` statement that bash executes as a command, failing with exit 127.

Every tick since 18:05Z today has exited 127 because of this, which triggered the crash detector and paused dispatch. Fresh ticks keep hitting the same error.

Deletes the stray line. All 10 unit tests in `tests/test-pr-pipeline-position.sh` still pass.