### PR TITLE
feat: deduplicate auto-filed issues (M1/PR 1)

### DIFF
--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -212,16 +212,13 @@ The tick loop is now paused and will not dispatch agents until the ROLLBACK mark
 EOF
 )
 
-      # Create the issue and apply breeze:human via the labeling helper.
+      # Use file_or_update_issue to prevent duplicates.
       # We don't set priority:high — per AGENTS.md no auto-priority labels.
-      new_issue_url=""
-      new_issue_url=$(gh issue create --repo "$REPO" \
-        --title "Automatic rollback: 3 consecutive tick crashes detected" \
-        --body "$issue_body" 2>&1 | tee -a "$LOG" | tail -1 || true)
       new_issue_n=""
-      new_issue_n=$(echo "$new_issue_url" | grep -oE '/issues/[0-9]+' | grep -oE '[0-9]+' || echo "")
+      new_issue_n=$(file_or_update_issue "$REPO" "Automatic rollback: 3 consecutive tick crashes detected" "$issue_body" "")
       if [[ -n "$new_issue_n" ]]; then
         set_breeze_state "$REPO" "$new_issue_n" human
+        log "filed or updated rollback issue #$new_issue_n"
       fi
     else
       log "ERROR: Could not find a known-good SHA in tick history — filing alert issue"
@@ -253,15 +250,12 @@ The tick loop is now paused and will not dispatch agents until the ROLLBACK mark
 EOF
 )
 
-      # Create the issue and apply breeze:human via the labeling helper.
-      new_issue_url=""
-      new_issue_url=$(gh issue create --repo "$REPO" \
-        --title "Tick crashing with no rollback target available" \
-        --body "$issue_body" 2>&1 | tee -a "$LOG" | tail -1 || true)
+      # Use file_or_update_issue to prevent duplicates.
       new_issue_n=""
-      new_issue_n=$(echo "$new_issue_url" | grep -oE '/issues/[0-9]+' | grep -oE '[0-9]+' || echo "")
+      new_issue_n=$(file_or_update_issue "$REPO" "Tick crashing with no rollback target available" "$issue_body" "")
       if [[ -n "$new_issue_n" ]]; then
         set_breeze_state "$REPO" "$new_issue_n" human
+        log "filed or updated no-rollback-target issue #$new_issue_n"
       fi
     fi
   fi
@@ -1029,18 +1023,13 @@ $log_excerpt
 
 The quarantine will auto-release when PR #$number gets new commits (HEAD SHA changes)."
 
-    # Create the issue and apply priority:high + breeze:human
-    local new_issue_url
-    new_issue_url=$(gh issue create --repo "$REPO" \
-      --title "hot-loop: $agent stuck on PR #$number" \
-      --body "$issue_body" \
-      --label "priority:high" 2>&1 | tee -a "$LOG" | tail -1 || true)
-
+    # Use file_or_update_issue to prevent duplicates.
+    # Apply priority:high + breeze:human to the issue.
     local new_issue_n
-    new_issue_n=$(echo "$new_issue_url" | grep -oE '/issues/[0-9]+' | grep -oE '[0-9]+' || echo "")
+    new_issue_n=$(file_or_update_issue "$REPO" "hot-loop: $agent stuck on PR #$number" "$issue_body" "--label priority:high")
     if [[ -n "$new_issue_n" ]]; then
       set_breeze_state "$REPO" "$new_issue_n" human
-      log "filed hot-loop bug issue #$new_issue_n"
+      log "filed or updated hot-loop bug issue #$new_issue_n"
     fi
   fi
 }


### PR DESCRIPTION
**drafter:**

Refs #798 (v0.2.0 roadmap M1/PR 1)

## Summary

Convert all direct `gh issue create` calls in tick.sh to use the existing `file_or_update_issue` helper function. This prevents cascade patterns where the same issue gets filed multiple times (e.g., #785→#787→#791→#793).

## Changes

- **Rollback issues**: Use `file_or_update_issue` for "Automatic rollback" alerts
- **No-rollback-target issues**: Use `file_or_update_issue` for crash alerts  
- **Hot-loop issues**: Use `file_or_update_issue` for "hot-loop: agent stuck" alerts

Each location now:
1. Calls `file_or_update_issue` with the issue title
2. If an issue with that exact title exists, appends a comment instead
3. Returns the issue number (existing or newly created)
4. Logs whether it filed or updated

## Test plan

Per issue #798, E2E test cases for this PR are:

- (a) Supervisor files divergence issue for PR #X → verify issue created
- (b) Supervisor detects SAME divergence on PR #Y → verify comment added to existing issue, not new issue
- (c) Supervisor detects divergence with DIFFERENT title → verify new issue created
- (d) Edge case: existing issue is closed → verify new issue created
- (e) Cold-start: fresh clone can run supervisor detection logic

Note: "Supervisor" here refers to any auto-filing logic in tick.sh (rollback detector, hot-loop detector, etc.), since the e2e-supervisor agent doesn't exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>