### PR TITLE
feat: extend duplicate-PR detection to find root-cause chains (M1/PR 2)

### DIFF
--- a/scripts/check-duplicate-pr.sh
+++ b/scripts/check-duplicate-pr.sh
@@ -4,6 +4,13 @@
 #
 # Usage: check-duplicate-pr.sh <repo> <issue-number>
 # Returns: JSON with matching PR info if found, empty otherwise
+#
+# Search strategy:
+# 1. Direct search: PRs that mention this issue (#N) in title/body
+# 2. Root-cause search: If this issue mentions a root-cause (e.g., "fixes #X"),
+#    find other open issues that also mention #X, then find PRs for those issues.
+#    This prevents cascades like #785→#787→#791→#793 where each new issue
+#    references #785 but drafter didn't realize they're all for the same bug.
 
 set -euo pipefail
 
@@ -30,5 +37,36 @@ combined=$(echo "$direct_prs" | jq -r --argjson mention "$mention_prs" --arg iss
   map(select(.body // "" | test("#" + $issue_num + "\\b") or (.title // "" | test("#" + $issue_num + "\\b"))))
 ')
 
+# Root-cause search: extract root-cause issue numbers from this issue's body
+# Look for patterns like "divergence on PR #785", "fixes #785", "refs #123", etc.
+issue_body=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json body --jq '.body // ""' 2>/dev/null || echo "")
+root_causes=$(echo "$issue_body" | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | head -5 || echo "")
+
+# For each root-cause, find other open issues that reference it, then find their PRs
+root_cause_prs="[]"
+for root_cause in $root_causes; do
+  [[ "$root_cause" == "$ISSUE_NUM" ]] && continue  # Skip self-reference
+
+  # Find open issues that mention this root-cause
+  related_issues=$(gh issue list --repo "$REPO" --state open --search "#$root_cause" --json number --jq '.[].number' 2>/dev/null || echo "")
+
+  for related_issue in $related_issues; do
+    [[ "$related_issue" == "$ISSUE_NUM" ]] && continue  # Skip self
+
+    # Find PRs for this related issue
+    related_prs=$(gh pr list --repo "$REPO" --state open --search "$related_issue in:body" --json number,headRefName,title,body 2>/dev/null || echo "[]")
+    if [[ "$(echo "$related_prs" | jq 'length')" -gt 0 ]]; then
+      root_cause_prs=$(echo "$root_cause_prs" | jq -r --argjson new "$related_prs" '. + $new')
+    fi
+  done
+done
+
+# Merge all results: direct mentions + root-cause chain
+all_prs=$(echo "$combined" | jq -r --argjson root "$root_cause_prs" '
+  . + $root |
+  group_by(.number) |
+  map(.[0])
+')
+
 # Return the first matching PR (if any)
-echo "$combined" | jq -r 'if length > 0 then .[0] else empty end'
+echo "$all_prs" | jq -r 'if length > 0 then .[0] else empty end'


### PR DESCRIPTION
**drafter:**

Refs #798 (v0.2.0 roadmap M1/PR 2)

## Summary

Extend `check-duplicate-pr.sh` to detect PRs for related issues that share the same root-cause. This prevents cascades like #785→#787→#791→#793 where each issue filed about the same underlying bug spawns a new PR.

## Changes

Enhanced search strategy:
1. **Direct search**: PRs that mention this issue (#N) in title/body (existing)
2. **Root-cause search** (NEW):
   - Extract issue references from this issue's body (e.g., "fixes #785")
   - For each root-cause, find other open issues that also reference it
   - Find PRs for those related issues
   - Return the first match

## Example

If issue #787 says "fixes divergence from #785" and issue #791 also says "fixes divergence from #785", when drafter is dispatched on #791, it will find the existing PR for #787 (via shared root-cause #785) and reuse that branch instead of opening a duplicate PR.

## Test plan

Per issue #798, E2E test cases for this PR are:

- (a) Drafter creates PR for issue #X → verify PR created
- (b) Drafter dispatched on SAME issue #X → verify no new PR, commits pushed to existing branch
- (c) Drafter dispatched on issue #Y that references same root-cause as #X → verify reuses PR from #X
- (d) Edge case: existing PR is closed → verify new PR created
- (e) Cold-start: fresh clone can run drafter dedup logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>