### PR TITLE
feat(reviewer): add build/typecheck/lint validation before approval (PR 2 from #832)

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -26,6 +26,35 @@ This prevents repeatedly flagging the same false positives across runs.
 
 You operate with **fresh context** on each invocation. Read the PR diff and linked issue at HEAD. While you may scan prior review comments to confirm resolutions, form your judgment independently without being biased by prior analysis.
 
+## Build pipeline check (MANDATORY)
+
+**Before forming any verdict**, run the project's build pipeline to catch mechanical errors early:
+
+1. **Detect project type** from repo root files:
+   - `package.json` → npm project
+   - `Cargo.toml` → Rust/cargo project
+   - `pyproject.toml` or `setup.py` → Python project
+   - If none found, skip build checks (no build pipeline to run)
+
+2. **For npm projects**, run these steps in sequence:
+   ```bash
+   npm install --no-audit
+   npm run build  # if "build" script exists in package.json
+   npx tsc --noEmit  # if tsconfig.json exists
+   npm run lint  # if "lint" script exists in package.json
+   ```
+
+3. **If ANY build step fails**:
+   - Capture the full error output
+   - Post a review with verdict `**reviewer verdict: changes-requested**`
+   - Include the build error in the review body
+   - Emit `action=changes-requested` and exit
+   - Do NOT proceed to code review — fix the build first
+
+4. **If build succeeds**, proceed with normal code review below.
+
+**Cost note:** This adds ~30s and $0.20-0.50 per PR, acceptable given it saves a 2-tick round-trip on most mechanical bugs. Out of scope: running unit tests (that's test-agent's job). Reviewer only verifies the code *compiles and lints clean*.
+
 ## Focus areas, in order
 
 1. **Does the code match the design?** Read the linked design-doc issue (`Fixes #<n>` in the PR body). Flag anything the PR does that wasn't in the design, or anything the design asked for that's missing.


### PR DESCRIPTION
**drafter:**

Reviewer now runs the project's build pipeline before forming a verdict to catch mechanical errors (TypeScript errors, lint failures, broken imports) before they reach test-agent.

## Changes

Build pipeline check (MANDATORY before verdict):

1. **Detect project type** from repo root files:
   - `package.json` → npm project
   - `Cargo.toml` → Rust/cargo project
   - `pyproject.toml` or `setup.py` → Python project
   - None found → skip build checks

2. **For npm projects**, run in sequence:
   - `npm install --no-audit`
   - `npm run build` (if "build" script exists)
   - `npx tsc --noEmit` (if tsconfig.json exists)
   - `npm run lint` (if "lint" script exists)

3. **If ANY step fails**:
   - Capture full error output
   - Post review with `**reviewer verdict: changes-requested**`
   - Include build error in review body
   - Emit `action=changes-requested` and exit
   - Do NOT proceed to code review

4. **If build succeeds**, proceed with normal code review

## Cost/benefit

- **Cost:** ~30s and $0.20-0.50 per PR
- **Benefit:** Saves a 2-tick round-trip on most mechanical bugs (TypeScript errors, lint failures)
- **Out of scope:** Running unit tests (that's test-agent's job)

Reviewer only verifies the code *compiles and lints clean*, not that it's functionally correct.

## Testing

All test cases from issue #832 E2E test plan for PR 2 should pass:
- (a) TypeScript error → changes-requested
- (b) Lint failure → changes-requested
- (c) Broken import → changes-requested
- (d) Clean code → approved
- (e) Non-npm project → graceful skip or correct detection
- (f) Cold-start compatibility

Refs #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>