### PR TITLE
patch: validate next-role hints; document fix-prefix footgun (refs https://github.com/serenakeyitan/git-bee/issues/841 https://github.com/serenakeyitan/git-bee/issues/855)

### DIFF
--- a/agents/drafter.md
+++ b/agents/drafter.md
@@ -76,6 +76,7 @@ Prior failure modes this rule exists to prevent:
 - **Never skip tests.** If tests fail, fix them — do not disable or `--no-verify`.
 - **Stop after 5 failed attempts.** Use `bee pause <n> "<reason>"` to label `breeze:human` and explain what you tried.
 - **Leave the claim clean.** When you exit, your `breeze:wip` should only remain on items you're still mid-work on.
+- **PR titles: avoid `fix(scope): ...` Conventional Commits prefix when the PR body mentions other issue numbers for context.** GitHub's auto-close parser interprets `fix(...)` titles as a closing keyword applied to every `#N` mentioned in the PR body. This silently closed #836 and #837 (see #841). Safe alternatives: `patch(scope)`, `dispatcher`, `chore(scope)`, scope-only. Reserve `fix(scope): ...` ONLY for PRs that legitimately want to close exactly one issue (linked via explicit `Fixes #<n>`) and DO NOT mention any other `#<n>` in the body — link those via full URLs (`https://github.com/serenakeyitan/git-bee/issues/<n>`) instead. Same applies to `Closes` and `Resolves` keywords.
 
 ## When blocked
 

--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -1175,12 +1175,31 @@ for t in $all_targets; do
 
   hint=$(check_next_hint "$t")
   if [[ -n "$hint" && "$hint" != "none" ]]; then
-    # Check anti-loop safety
-    if ! check_hint_loop "$hint" "$t"; then
-      hint_target="$hint $t"
-      log "dispatch: using hint from activity log - $hint on #$t"
-      break
+    if check_hint_loop "$hint" "$t"; then
+      continue
     fi
+    # Validate hint against current pipeline position for PRs (#855).
+    # Stale hints from before the PR's state advanced cause re-quarantine loops.
+    is_pr=$(gh pr view "$t" --repo "$REPO" --json number --jq '.number' 2>/dev/null || echo "")
+    if [[ -n "$is_pr" ]]; then
+      pr_json=$(gh pr view "$t" --repo "$REPO" --json number,reviewDecision,labels,reviews,comments,headRefOid,mergeable,mergeStateStatus 2>/dev/null || echo "{}")
+      position=$(pr_pipeline_position "$pr_json")
+      expected_role=""
+      case "$position" in
+        ready-to-merge)        expected_role="merger" ;;
+        approved-e2e-stale)    expected_role="test-agent" ;;
+        approved-e2e-failed)   expected_role="test-agent" ;;
+        conflicted|needs-drafter-feedback|needs-drafter-review) expected_role="drafter" ;;
+        needs-review)          expected_role="reviewer" ;;
+      esac
+      if [[ -n "$expected_role" && "$hint" != "$expected_role" ]]; then
+        log "dispatch: hint stale ($hint vs expected $expected_role for position $position on #$t) — discarding"
+        continue
+      fi
+    fi
+    hint_target="$hint $t"
+    log "dispatch: using hint from activity log - $hint on #$t"
+    break
   fi
 done
 


### PR DESCRIPTION
**human:**

Manual fixes for two meta-bugs that block the autonomous loop from fixing itself.

Refs: see https://github.com/serenakeyitan/git-bee/issues/841 and https://github.com/serenakeyitan/git-bee/issues/855 (linking via URL on purpose, per the rule this PR adds).

## Why I'm doing this manually

These bugs are bootstrap-blocked: drafter would have to write a `fix(...)` PR (triggering #841) and emit hints (triggering #855) to fix them. The system can't fix the bugs that prevent it from fixing things.

## Changes

### scripts/tick.sh — validate hints against pipeline position

When a next-role hint is found for a PR, validate it against `pr_pipeline_position` before honoring. If the hint says `drafter` but the PR is approved-e2e-stale (should go to test-agent), discard the hint and fall through to `pick_target`. Prevents stale-hint re-dispatch loops.

Issues don't have a pipeline position, so still trust hints there.

### agents/drafter.md — fix-prefix guidance

Add a rule against `fix(scope): ...` Conventional Commits titles when the body mentions other issue numbers. GitHub's auto-close parser interprets `fix(...)` as a closing keyword applied to every `#N` in the body. Recommend full-URL references for context.

## Tests

All 10 unit tests in `tests/test-pr-pipeline-position.sh` pass.