### PR TITLE
patch: drop --search from dedupe helper (caused 12-watchdog cascade today)

### DIFF
--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -27,7 +27,11 @@ source "$HERE/labels.sh"
 file_or_update_issue() {
   local repo="$1" title="$2" body="$3" extra_args="${4:-}" agent_role="${5:-tick}"
   local existing
-  existing=$(gh issue list --repo "$repo" --state open --search "in:title \"$title\"" --json number,title --jq ".[] | select(.title == \"$title\") | .number" 2>/dev/null | head -1 || echo "")
+  # Drop --search: it overrides --state open and returns closed issues, ranked
+  # by recency. That caused 12 watchdog dups today (#870-#881) when the
+  # ranking buried the actually-open match below recently-closed ones.
+  # Just list all open issues and jq-filter exactly. A bit slower but correct.
+  existing=$(gh issue list --repo "$repo" --state open --limit 200 --json number,title --jq ".[] | select(.title == \"$title\") | .number" 2>/dev/null | head -1 || echo "")
   if [[ -n "$existing" ]]; then
     log "file_or_update_issue: #$existing already open with title '''$title''' — appending comment"
     gh issue comment "$existing" --repo "$repo" --body "$body" >/dev/null 2>&1 || true


### PR DESCRIPTION
**human:**

`gh issue list --search` overrides `--state open` and returns closed issues ranked by recency. When recent dups exist in closed state, `head -1` returns a closed issue → helper posts comment to closed → next tick still doesn't see the open one → creates new dup.

Today's visible damage: 12 watchdog issues filed in 33 minutes (issues #870-#881).

Fix: drop `--search`, list all open with `--limit 200`, jq-filter exact title. Correct, slightly slower.