### PR TITLE
feat(tick): add check_already_resolved predicate (M2/PR 2)

### DIFF
--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -843,13 +843,10 @@ check_already_resolved() {
 
   # Find the most recent end event for this (agent, target)
   local last_event
-  last_event=$(jq -r --arg agent "$agent" \
-    --arg target "#${number}" \
-    'select(.event == "end" and
-            .agent == $agent and
-            .target == $target) |
-     [., input] | .[0]' \
-    "$activity_log" 2>/dev/null | tail -1 || echo "")
+  last_event=$(grep -F "\"event\":\"end\"" "$activity_log" | \
+    grep -F "\"agent\":\"$agent\"" | \
+    grep -F "\"target\":\"#${number}\"" | \
+    tail -1)
 
   [[ -z "$last_event" ]] && return 1
 

--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -829,6 +829,71 @@ pick_target() {
   done
 }
 
+# Already-resolved skip predicate (issue #891).
+# Returns 0 if the most recent end event for (agent, target) was no-op-* AND
+# the PR's current head_sha and last_comment_ts both match the snapshot in that
+# event (meaning nothing has changed since the agent last inspected).
+# Returns 1 otherwise (allow dispatch).
+check_already_resolved() {
+  local agent="$1" number="$2"
+  local activity_log="${LOG_DIR}/activity.ndjson"
+
+  # No activity log means allow dispatch
+  [[ ! -f "$activity_log" ]] && return 1
+
+  # Find the most recent end event for this (agent, target)
+  local last_event
+  last_event=$(jq -r --arg agent "$agent" \
+    --arg target "#${number}" \
+    'select(.event == "end" and
+            .agent == $agent and
+            .target == $target) |
+     [., input] | .[0]' \
+    "$activity_log" 2>/dev/null | tail -1 || echo "")
+
+  [[ -z "$last_event" ]] && return 1
+
+  # Extract outcome, head_sha, last_comment_ts from the last event
+  local outcome head_sha_snap last_comment_snap
+  outcome=$(jq -r '.outcome // ""' <<<"$last_event")
+  head_sha_snap=$(jq -r '.head_sha // ""' <<<"$last_event")
+  last_comment_snap=$(jq -r '.last_comment_ts // ""' <<<"$last_event")
+
+  # Only skip if outcome was no-op-*
+  if [[ ! "$outcome" =~ ^no-op- ]]; then
+    return 1  # Not a no-op outcome, allow dispatch
+  fi
+
+  # Get current PR state
+  local current_head_sha current_last_comment_ts
+  current_head_sha=$(gh pr view "$number" --repo "$REPO" --json headRefOid --jq '.headRefOid // ""' 2>/dev/null || echo "")
+
+  # Get current last comment timestamp (same logic as activity.sh get_last_comment_ts)
+  local comments_json reviews_json
+  comments_json=$(gh issue view "$number" --repo "$REPO" --json comments --jq '[.comments[]? | .createdAt] | max // ""' 2>/dev/null || echo "")
+  reviews_json=$(gh pr view "$number" --repo "$REPO" --json reviews --jq '[.reviews[]? | .submittedAt] | max // ""' 2>/dev/null || echo "")
+
+  if [[ -n "$comments_json" && -n "$reviews_json" ]]; then
+    current_last_comment_ts=$(printf '%s\n%s' "$comments_json" "$reviews_json" | sort -r | head -1)
+  elif [[ -n "$comments_json" ]]; then
+    current_last_comment_ts="$comments_json"
+  elif [[ -n "$reviews_json" ]]; then
+    current_last_comment_ts="$reviews_json"
+  else
+    current_last_comment_ts=""
+  fi
+
+  # Compare: if both head_sha and last_comment_ts unchanged, skip dispatch
+  if [[ "$current_head_sha" == "$head_sha_snap" ]] && \
+     [[ "$current_last_comment_ts" == "$last_comment_snap" ]]; then
+    log "already-resolved: skip dispatch of $agent on #$number (outcome=$outcome, head_sha unchanged, no new comments)"
+    return 0  # Skip dispatch
+  fi
+
+  # State changed — allow dispatch
+  return 1
+}
+
 # Hot loop detector — check if the same agent has been dispatched N times
 # with exit_code=0 and outcome=null or refused-by-guard outcomes to the same
 # target within a time window.
@@ -1624,6 +1689,14 @@ Auto-release $release_count/3. The \`breeze:quarantine-hotloop\` label has been 
 # Check for quarantine auto-release before dispatch
 if [[ -n "$target" ]]; then
   check_quarantine_release "$number"
+fi
+
+# Check if already resolved (issue #891) — skip dispatch if agent last ran
+# with no-op-* outcome and PR state (head_sha + last_comment_ts) unchanged
+if check_already_resolved "$kind" "$number"; then
+  log "skip: already-resolved for $kind on #$number — no state change since last no-op"
+  log "tick end (pid=$$ exit=already-resolved)"
+  exit 0
 fi
 
 # Check for hot loop before dispatching


### PR DESCRIPTION
**drafter:**

Implements the dispatcher skip predicate to prevent re-dispatching agents when nothing has changed since their last no-op run.

## Changes

- Add `check_already_resolved()` function
- Wire into dispatch path BEFORE `check_hot_loop`
- Skip dispatch when last outcome was `no-op-*` AND both `head_sha` and `last_comment_ts` match the snapshot in the last end event
- Re-dispatch when either SHA or comments advance

## Logic

1. Fetch most recent end event for `(agent, target)`
2. If outcome was `no-op-*`, compare current PR state to snapshot
3. If both `head_sha` and `last_comment_ts` unchanged → skip dispatch
4. Otherwise → allow dispatch

## Trade-off accepted

Bee's own comments trigger re-dispatch (small waste, simple rule). This is acceptable because `check_already_resolved` prevents genuine routing disagreements from reaching `check_hot_loop`.

## Outcome

Hot-loop detector returns to being a backstop for true pathology, not the front-line defense against dispatcher/agent disagreement.

## Acceptance

- Dispatcher skips `(agent, target, head_sha)` tuples when last outcome was `no-op-*` and state unchanged
- Re-dispatch when SHA or comments advance
- Hot-loop firings drop to ~zero for recurring no-op patterns

## E2E test plan (preview)

See issue #891 for full E2E plan. Key cases:
- Already-resolved skip fires correctly
- check_already_resolved runs before check_hot_loop
- Re-dispatch on state change (new commits or comments)
- Bee comment triggers re-dispatch (accepted waste)
- Cold-start compatibility

Refs #891

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>