### PR TITLE
docs(AGENTS): document outcome contract and dispatcher skip rule (M2/PR 4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,36 @@ Every agent ends its stdout with one line matching:
 
 `tick.sh` parses this to populate `activity.ndjson` and to drive next-role hints. Acceptable field names: `action=`, `result=`, `verdict=`. If none is present, the tick treats it as a null outcome and writes a failure file.
 
+## Outcome contract (issue #891)
+
+Every agent's terminating comment must include an **outcome marker** from a closed enum. The activity log captures this to enable the dispatcher to skip re-dispatch when nothing has changed since the agent's last no-op run.
+
+### Closed outcome enum
+
+| Outcome | Meaning | Example agents |
+|---|---|---|
+| `progressed` | Agent took a state-changing action (push, comment, review, merge, pause, label) | All agents when they do work |
+| `no-op-already-done` | Agent inspected at this SHA and found nothing to do | Reviewer already reviewed HEAD, test-agent already passed E2E at HEAD |
+| `no-op-waiting` | Blocked on another agent or human | Merger waiting for E2E, drafter waiting for approval |
+| `no-op-stale-input` | Refused due to stale E2E or outdated approval marker | Merger refuses stale E2E pass |
+| `escalated` | Agent called `bee pause` (also sets `breeze:human`) | Any agent on blocker |
+| `error` | `exit_code != 0` | Automatic mapping by `activity.sh` |
+| `no-op-unclassified` | Fallback when outcome missing/invalid (WARN in `tick.log`) | Agent bug — fix the terminating comment |
+
+### Enforcement and validation
+
+- **`activity.sh cmd_end`** validates outcome via `validate_outcome()`. If `exit_code != 0`, outcome is forced to `error`. If outcome is empty or invalid, it maps to `no-op-unclassified` and logs WARN to `tick.log`.
+- **`activity.sh cmd_end`** captures `head_sha` (PR only) and `last_comment_ts` in the `end` event.
+- **`tick.sh check_already_resolved`** runs BEFORE `check_hot_loop`. If the most recent `end` event for `(agent, target)` was `no-op-*` AND the PR's current `head_sha` and `last_comment_ts` both match the snapshot in that event, the dispatcher skips dispatch. Re-dispatch happens when either SHA or comments advance.
+
+### Trade-off accepted
+
+Single-account mode means bee cannot distinguish bee comments from human comments without HTML markers on every code path. We accept that bee's own comments will trigger re-dispatch — small waste, simple rule. The hot-loop detector still catches genuine pathology.
+
+### Hot-loop detector as backstop
+
+With `check_already_resolved` in place, the hot-loop detector returns to being a true backstop for genuine agent bugs (infinite loops, SIGSEGVs, prompt regression), not the front-line defense against routing disagreements.
+
 ## Claims
 
 Claim acquisition is label-based (via `breeze:wip`) plus a freshness comment marker (`<!-- breeze:claimed-at=<ISO8601> by=<agent-id> -->`). A claim is stale once the labeled-event timestamp is older than `CLAIM_TTL_SECONDS` (default 7200 = 2h). Any agent may take over a stale claim.


### PR DESCRIPTION
**drafter:**

Adds comprehensive documentation of the outcome contract to AGENTS.md, explaining the closed enum, validation, and dispatcher skip logic.

## Changes

- Add "Outcome contract (issue #891)" section after Status-line contract
- Document closed outcome enum with meaning and examples
- Explain enforcement (activity.sh validates, tick.sh skips re-dispatch)
- Document trade-off (bee comments trigger re-dispatch)
- Clarify hot-loop detector's new role (backstop, not front-line)

## Key points

- **Every agent must emit outcome marker from closed enum**
- **activity.sh validates** and captures `head_sha` + `last_comment_ts`
- **tick.sh check_already_resolved** skips dispatch when `(agent, target, SHA)` unchanged and last outcome was `no-op-*`
- **Re-dispatch when SHA or comments advance**
- **Hot-loop detector now catches genuine bugs**, not routing disagreements

## Integration

This completes the 4-PR milestone:
1. PR #892: activity.sh enforces enum, captures SHA + comment timestamp
2. PR #893: tick.sh adds check_already_resolved predicate
3. PR #894: agent prompts document outcome vocabulary
4. This PR: AGENTS.md documents the full contract

## Acceptance

- Documentation reflects actual behavior
- Enum, validation, and skip rule documented
- Trade-offs and edge cases covered

Refs #891

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>