### PR TITLE
patch(#901): route e2e-failed to drafter; expand outcome enum

### DIFF
--- a/scripts/activity.sh
+++ b/scripts/activity.sh
@@ -53,6 +53,7 @@ validate_outcome() {
 
   # Valid enum values
   local valid_outcomes=(
+    # Generic outcomes (any agent)
     "progressed"
     "no-op-already-done"
     "no-op-waiting"
@@ -60,6 +61,27 @@ validate_outcome() {
     "escalated"
     "error"
     "no-op-unclassified"
+    # Reviewer-specific
+    "approved"
+    "changes-requested"
+    "skipped-already-reviewed"
+    # Test-agent specific (per agents/test-agent.md classifications)
+    "passed"
+    "skipped-scripts-only"
+    "code-bug"
+    "test-bug"
+    "lazy-run"
+    "design-trivial"
+    "design-conflicting"
+    # Merger-specific
+    "merged"
+    "skipped-not-approved"
+    "skipped-stale-e2e"
+    # Drafter-specific
+    "implemented"
+    "implemented-tiny"
+    "drafted"
+    "designed-test-plan"
   )
 
   # Check if raw_outcome is in the valid set

--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -671,7 +671,7 @@ pick_target() {
   #
   #   ready-to-merge         → merger
   #   approved-e2e-stale     → test-agent
-  #   approved-e2e-failed    → test-agent
+  #   approved-e2e-failed    → drafter (was: test-agent — caused #897 loop)
   #   conflicted             → drafter
   #   needs-drafter-feedback → drafter
   #   needs-drafter-review   → drafter
@@ -697,7 +697,14 @@ pick_target() {
         return
         ;;
       approved-e2e-failed)
-        echo "test-agent $pr_num"
+        # E2E failed at HEAD. test-agent already classified the failure
+        # (code-bug | test-bug | lazy-run | design-trivial | design-conflicting)
+        # in its **E2E trace (fail)** comment. Re-running test-agent just
+        # repeats the same classification — wasteful and triggers loops
+        # (#897 today). Route to drafter, who reads the failure trace and
+        # decides: fix the code (code-bug), rewrite the test (test-bug),
+        # re-run (lazy-run), or escalate (design-*).
+        echo "drafter $pr_num"
         return
         ;;
       conflicted|needs-drafter-feedback|needs-drafter-review)
@@ -1279,7 +1286,7 @@ for t in $all_targets; do
       case "$position" in
         ready-to-merge)        expected_role="merger" ;;
         approved-e2e-stale)    expected_role="test-agent" ;;
-        approved-e2e-failed)   expected_role="test-agent" ;;
+        approved-e2e-failed)   expected_role="drafter" ;;
         conflicted|needs-drafter-feedback|needs-drafter-review) expected_role="drafter" ;;
         needs-review)          expected_role="reviewer" ;;
       esac


### PR DESCRIPTION
**human:**

Fixes the loop seen on PR #897 yesterday. Two related fixes:

1. `approved-e2e-failed` now routes to drafter (not test-agent). Test-agent already classified the failure in its trace comment; re-running it just repeats. Drafter reads the failure and acts.
2. `activity.sh` outcome enum expanded to cover all real agent outcomes (approved, code-bug, test-bug, etc.). Previously these all became `no-op-unclassified`, which compounded with #900's check.

All 10 unit tests in `tests/test-pr-pipeline-position.sh` pass.

References https://github.com/serenakeyitan/git-bee/issues/901.