### PR TITLE
feat(planner): add ROADMAP.md reader for backlog maintenance (M3/PR 7)

### DIFF
--- a/agents/planner.md
+++ b/agents/planner.md
@@ -12,6 +12,10 @@ If the environment variable `GIT_BEE_LAST_FAILURE` is set, read the file at that
 
 ## Your job
 
+The planner operates in two modes:
+
+### Mode 1: Design-doc issue planning (primary)
+
 Read finalized design-doc issues and create structured milestone plans that break the work into appropriately-sized PRs.
 
 1. Skip bug reports - if the issue title starts with `bug:`, `fix:`, or contains `regression`, exit with `planner: issue=<n> action=skipped-bug-report next=drafter`.
@@ -21,6 +25,24 @@ Read finalized design-doc issues and create structured milestone plans that brea
 5. Create a dependency graph showing which PRs must land before others.
 6. Append a `## Milestone plan` section to the issue body with the structured plan.
 7. If the plan requires more than 8 PRs, tag `breeze:human` and ask to split the design-doc into multiple issues.
+
+### Mode 2: Roadmap-driven backlog maintenance (runs when dispatcher is idle)
+
+When the dispatcher has no active work (invoked without a specific issue target), maintain the backlog from the roadmap:
+
+1. Check if `ROADMAP.md` exists at the repo root. If not, exit with `planner: action=no-roadmap next=none`.
+2. Parse milestone definitions from ROADMAP.md. Format: `## vX.Y.Z - [Title]` marks a milestone header.
+3. For each milestone in order:
+   - Check if an issue already exists with that exact milestone version in its title (e.g., "v0.2.0")
+   - Check if the milestone is complete (all PRs merged, issue closed)
+4. If the backlog is thin (< 3 open `type:design-doc` issues) AND there's an unimplemented milestone in the roadmap:
+   - File a new issue for the next unimplemented milestone
+   - Title: `[Milestone version] - [Milestone title from roadmap]`
+   - Body: Copy the full milestone section from ROADMAP.md
+   - Labels: `type:design-doc`, `source:roadmap`
+   - Exit with `planner: action=filed-roadmap-issue issue=<new-issue-number> next=none`
+   - **Limit:** File at most ONE new issue per invocation (prevents backlog flooding)
+5. If all roadmap milestones have issues or are complete, exit with `planner: action=roadmap-complete next=none`.
 
 ## Output format
 
@@ -63,10 +85,12 @@ If the design is unclear or contradictory:
 
 ## Output
 
-End with: `planner: issue=<n> action=<planned|escalated-too-many-prs|gave-up-breeze-human|skipped-bug-report> next=<role|none>`.
+End with: `planner: issue=<n> action=<planned|escalated-too-many-prs|gave-up-breeze-human|skipped-bug-report|filed-roadmap-issue|roadmap-complete|no-roadmap> next=<role|none>`.
 
 Next-role hints:
-- After planning: `next=e2e-designer`
+- After planning (Mode 1): `next=e2e-designer`
+- After filing a roadmap issue (Mode 2): `next=none`
+- After roadmap complete or no roadmap: `next=none`
 - After escalating or pausing for human: `next=none`
 
 ## Outcome markers (issue #891)

--- a/tests/e2e/test-planner-roadmap.sh
+++ b/tests/e2e/test-planner-roadmap.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# E2E test for M3/PR 7: Planner roadmap-driven backlog maintenance
+#
+# Test cases:
+# (a) Planner prompt includes ROADMAP.md parsing logic
+# (b) Mode 2 (roadmap maintenance) is defined
+# (c) Milestone completion checks exist
+# (d) Roadmap-related action types are defined
+# (e) source:roadmap label is included
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+passed=0
+total=5
+
+cleanup() {
+  # Clean up test artifacts
+  rm -f /tmp/git-bee-test-planner-roadmap-$$ 2>/dev/null || true
+}
+trap cleanup EXIT
+
+log() {
+  echo "[test-planner-roadmap] $*" >&2
+}
+
+# Test (a): Planner prompt includes ROADMAP.md parsing logic
+test_a() {
+  log "Test (a): Planner prompt includes ROADMAP.md parsing logic"
+
+  if grep -q "ROADMAP.md" "$REPO_ROOT/agents/planner.md"; then
+    log "✓ planner.md references ROADMAP.md"
+    ((passed++))
+    return 0
+  else
+    log "✗ planner.md missing ROADMAP.md parsing logic"
+    return 1
+  fi
+}
+
+# Test (b): Mode 2 (roadmap maintenance) is defined
+test_b() {
+  log "Test (b): Mode 2 (roadmap maintenance) is defined"
+
+  if grep -q "Mode 2:" "$REPO_ROOT/agents/planner.md"; then
+    log "✓ planner.md defines Mode 2"
+    ((passed++))
+    return 0
+  else
+    log "✗ planner.md missing Mode 2 definition"
+    return 1
+  fi
+}
+
+# Test (c): Milestone completion checks exist
+test_c() {
+  log "Test (c): Milestone completion checks exist"
+
+  # Check for milestone parsing pattern (vX.Y.Z format)
+  if grep -qE "v[0-9]+\.[0-9]+\.[0-9]+" "$REPO_ROOT/agents/planner.md"; then
+    log "✓ planner.md includes milestone version pattern"
+    ((passed++))
+    return 0
+  else
+    log "✗ planner.md missing milestone version pattern"
+    return 1
+  fi
+}
+
+# Test (d): Roadmap-related action types are defined
+test_d() {
+  log "Test (d): Roadmap-related action types are defined"
+
+  local required_actions=(
+    "filed-roadmap-issue"
+    "roadmap-complete"
+    "no-roadmap"
+  )
+
+  local missing=0
+  for action in "${required_actions[@]}"; do
+    if ! grep -q "$action" "$REPO_ROOT/agents/planner.md"; then
+      log "✗ missing action type: $action"
+      missing=$((missing + 1))
+    fi
+  done
+
+  if [[ $missing -eq 0 ]]; then
+    log "✓ all roadmap action types defined"
+    ((passed++))
+    return 0
+  else
+    log "✗ $missing action type(s) missing"
+    return 1
+  fi
+}
+
+# Test (e): source:roadmap label is included
+test_e() {
+  log "Test (e): source:roadmap label is included"
+
+  if grep -q "source:roadmap" "$REPO_ROOT/agents/planner.md"; then
+    log "✓ planner.md includes source:roadmap label"
+    ((passed++))
+    return 0
+  else
+    log "✗ planner.md missing source:roadmap label"
+    return 1
+  fi
+}
+
+# Run all tests
+log "Running M3/PR 7 planner roadmap tests"
+
+test_a || true
+test_b || true
+test_c || true
+test_d || true
+test_e || true
+
+# Output JSON result
+echo "{\"passed\": $passed, \"total\": $total}"
+
+# Exit 0 regardless of pass/fail (JSON is the verdict)
+exit 0


### PR DESCRIPTION
**drafter:**

Implements M3/PR 7 from #798: extends planner agent with roadmap-driven backlog maintenance.

## Summary

Enables 8+ hour autonomous operation: when current work depletes, planner automatically queues the next roadmap milestone instead of going idle. Part of v0.2.0's "autonomous-safe" theme.

## Changes

### 1. Updated `agents/planner.md`
- Added **Mode 2: Roadmap-driven backlog maintenance**
- Planner now reads `ROADMAP.md` at repo root when dispatcher is idle
- Parses milestone definitions (format: `## vX.Y.Z - [Title]`)
- Checks which milestones already have issues filed
- Files new issues for next unimplemented milestone if backlog is thin (< 3 open design-doc issues)
- Labels new issues with `type:design-doc` and `source:roadmap`
- Prevents filing duplicates (max 1 issue per invocation)

### 2. New output actions
- `filed-roadmap-issue`: Filed a new milestone issue from roadmap
- `roadmap-complete`: All roadmap milestones have issues or are complete
- `no-roadmap`: ROADMAP.md doesn't exist

### 3. E2E test coverage
Created `tests/e2e/test-planner-roadmap.sh` with 5 test cases:
- (a) Planner prompt includes ROADMAP.md parsing logic ✓
- (b) Mode 2 (roadmap maintenance) is defined ✓
- (c) Milestone completion checks exist ✓
- (d) Roadmap-related action types are defined ✓
- (e) source:roadmap label is included ✓

All tests pass: `{"passed": 5, "total": 5}`

## Why this matters

- Enables autonomous backlog maintenance from canonical roadmap source
- Prevents idle loops when current work queue is empty
- Ensures next milestone gets queued automatically
- Part of v0.2.0's vision: 8+ hour unattended operation with self-recovery

## Test plan

```bash
tests/e2e/test-planner-roadmap.sh
```

Expected output: `{"passed": 5, "total": 5}`

## Dependencies

- Depends on: Nothing (first PR in M3 sequence)
- Enables: M3/PR 8 (ROADMAP.md scaffold) and M3/PR 9 (dispatcher roadmap priority)

Refs #798

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>