### PR TITLE
feat(parse): extract agent status-line parser to scripts/parse-status.sh (M4/PR 11)

### DIFF
--- a/scripts/parse-status.sh
+++ b/scripts/parse-status.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Parse agent status line and output JSON
+#
+# Usage:
+#   parse-status.sh <status-line>
+#   parse-status.sh --from-file <output-file> <agent-kind>
+#   parse-status.sh --from-log <log-file> <agent-kind>
+#
+# Output: JSON with fields: outcome, next
+#   {"outcome": "approved", "next": "e2e"}
+#   {"outcome": "", "next": ""}  (if no status line found)
+#
+# Status line format:
+#   <agent-kind>: [other fields...] action=<value> next=<value>
+#   <agent-kind>: [other fields...] result=<value> next=<value>
+#   <agent-kind>: [other fields...] verdict=<value> next=<value>
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<EOF
+Usage:
+  parse-status.sh <status-line>
+  parse-status.sh --from-file <output-file> <agent-kind>
+  parse-status.sh --from-log <log-file> <agent-kind>
+
+Parses agent status line and outputs JSON: {"outcome": "...", "next": "..."}
+EOF
+  exit 1
+}
+
+parse_status_line() {
+  local status_line="$1"
+  local outcome="" next=""
+
+  if [[ -n "$status_line" ]]; then
+    # Parse outcome field (could be action=, result=, or verdict=)
+    outcome=$(echo "$status_line" | grep -oE '(action|result|verdict)=[^ ]+' | cut -d= -f2 | head -1 || echo "")
+    # Parse next field
+    next=$(echo "$status_line" | grep -oE 'next=[^ ]+' | cut -d= -f2 | head -1 || echo "")
+  fi
+
+  # Output JSON
+  printf '{"outcome": "%s", "next": "%s"}\n' "$outcome" "$next"
+}
+
+case "${1:-}" in
+  --from-file)
+    [[ $# -eq 3 ]] || usage
+    output_file="$2"
+    agent_kind="$3"
+
+    if [[ ! -f "$output_file" ]]; then
+      # File doesn't exist, output empty result
+      printf '{"outcome": "", "next": ""}\n'
+      exit 0
+    fi
+
+    # Extract last status line matching agent kind
+    status_line=$(grep -E "^${agent_kind}:" "$output_file" | tail -1 || echo "")
+    parse_status_line "$status_line"
+    ;;
+
+  --from-log)
+    [[ $# -eq 3 ]] || usage
+    log_file="$2"
+    agent_kind="$3"
+
+    if [[ ! -f "$log_file" ]]; then
+      # File doesn't exist, output empty result
+      printf '{"outcome": "", "next": ""}\n'
+      exit 0
+    fi
+
+    # Extract last status line matching agent kind from timestamped log
+    # Log format: "YYYY-MM-DDTHH:MM:SSZ agent-kind: ..."
+    status_line=$(tail -100 "$log_file" | grep -E "^[0-9T:Z-]+ ${agent_kind}:" | tail -1 | cut -d' ' -f2- || echo "")
+    parse_status_line "$status_line"
+    ;;
+
+  --help|-h)
+    usage
+    ;;
+
+  *)
+    # Direct status line parsing (including empty string)
+    if [[ $# -ne 1 ]]; then
+      usage
+    fi
+    parse_status_line "$1"
+    ;;
+esac

--- a/scripts/tick.sh
+++ b/scripts/tick.sh
@@ -1857,10 +1857,10 @@ if [[ "${GIT_BEE_UI:-}" == "tmux" ]] && command -v tmux >/dev/null 2>&1 && tmux 
   if [[ "$kind" == "test-agent" ]]; then
     # Use wrapper for test-agent to capture metrics
     tmux new-window -t git-bee: -n "${kind}-#${number}" \
-      "cd '$REPO_ROOT' && output_file=\"/tmp/git-bee-agent-output-\$\$\"; '$HERE/test-agent-wrapper.sh' '$number' '$prompt_file' 2>&1 | tee \"\$output_file\" | tee -a '$LOG'; exit_code=\$?; status_line=\$(grep -E \"^${kind}:\" \"\$output_file\" 2>/dev/null | tail -1 || echo \"\"); agent_outcome=\$(echo \"\$status_line\" | grep -oE '(action|result|verdict)=[^ ]+' | cut -d= -f2 | head -1 || echo \"\"); agent_next=\$(echo \"\$status_line\" | grep -oE 'next=[^ ]+' | cut -d= -f2 | head -1 || echo \"\"); rm -f \"\$output_file\" '$prompt_file'; echo ''; echo \"Agent exited with code \$exit_code\"; '$REPO_ROOT/scripts/activity.sh' end '$REPO' '$kind' '$number' '$agent_id' \$exit_code \$(( SECONDS - $DISPATCH_START_TS )) \"\$agent_outcome\" \"\$agent_next\" 2>/dev/null || true; sleep 2; echo 'Self-triggering next tick (issue #724)'; '$HERE/tick.sh' 2>&1 | tail -5; sleep 3; exit \$exit_code"
+      "cd '$REPO_ROOT' && output_file=\"/tmp/git-bee-agent-output-\$\$\"; '$HERE/test-agent-wrapper.sh' '$number' '$prompt_file' 2>&1 | tee \"\$output_file\" | tee -a '$LOG'; exit_code=\$?; parsed=\$('$REPO_ROOT/scripts/parse-status.sh' --from-file \"\$output_file\" '${kind}'); agent_outcome=\$(echo \"\$parsed\" | jq -r '.outcome'); agent_next=\$(echo \"\$parsed\" | jq -r '.next'); rm -f \"\$output_file\" '$prompt_file'; echo ''; echo \"Agent exited with code \$exit_code\"; '$REPO_ROOT/scripts/activity.sh' end '$REPO' '$kind' '$number' '$agent_id' \$exit_code \$(( SECONDS - $DISPATCH_START_TS )) \"\$agent_outcome\" \"\$agent_next\" 2>/dev/null || true; sleep 2; echo 'Self-triggering next tick (issue #724)'; '$HERE/tick.sh' 2>&1 | tail -5; sleep 3; exit \$exit_code"
   else
     tmux new-window -t git-bee: -n "${kind}-#${number}" \
-      "cd '$REPO_ROOT' && output_file=\"/tmp/git-bee-agent-output-\$\$\"; '$CLAUDE_BIN' -p \"\$(cat '$prompt_file')\" --permission-mode bypassPermissions 2>&1 | tee \"\$output_file\" | tee -a '$LOG'; exit_code=\$?; status_line=\$(grep -E \"^${kind}:\" \"\$output_file\" 2>/dev/null | tail -1 || echo \"\"); agent_outcome=\$(echo \"\$status_line\" | grep -oE '(action|result|verdict)=[^ ]+' | cut -d= -f2 | head -1 || echo \"\"); agent_next=\$(echo \"\$status_line\" | grep -oE 'next=[^ ]+' | cut -d= -f2 | head -1 || echo \"\"); rm -f \"\$output_file\" '$prompt_file'; echo ''; echo \"Agent exited with code \$exit_code\"; '$REPO_ROOT/scripts/activity.sh' end '$REPO' '$kind' '$number' '$agent_id' \$exit_code \$(( SECONDS - $DISPATCH_START_TS )) \"\$agent_outcome\" \"\$agent_next\" 2>/dev/null || true; sleep 2; echo 'Self-triggering next tick (issue #724)'; '$HERE/tick.sh' 2>&1 | tail -5; sleep 3; exit \$exit_code"
+      "cd '$REPO_ROOT' && output_file=\"/tmp/git-bee-agent-output-\$\$\"; '$CLAUDE_BIN' -p \"\$(cat '$prompt_file')\" --permission-mode bypassPermissions 2>&1 | tee \"\$output_file\" | tee -a '$LOG'; exit_code=\$?; parsed=\$('$REPO_ROOT/scripts/parse-status.sh' --from-file \"\$output_file\" '${kind}'); agent_outcome=\$(echo \"\$parsed\" | jq -r '.outcome'); agent_next=\$(echo \"\$parsed\" | jq -r '.next'); rm -f \"\$output_file\" '$prompt_file'; echo ''; echo \"Agent exited with code \$exit_code\"; '$REPO_ROOT/scripts/activity.sh' end '$REPO' '$kind' '$number' '$agent_id' \$exit_code \$(( SECONDS - $DISPATCH_START_TS )) \"\$agent_outcome\" \"\$agent_next\" 2>/dev/null || true; sleep 2; echo 'Self-triggering next tick (issue #724)'; '$HERE/tick.sh' 2>&1 | tail -5; sleep 3; exit \$exit_code"
   fi
 
   # Run janitor to clean up old windows
@@ -1885,16 +1885,15 @@ else
       exit_code=$?
 
       # Parse agent's stdout for outcome and next hint
-      agent_outcome="" agent_next=""
+      # Parse agent status line using helper
       if [[ -f "$output_file" ]]; then
-        status_line=$(grep -E "^${kind}:" "$output_file" | tail -1 || echo "")
-        if [[ -n "$status_line" ]]; then
-          # Parse outcome field (could be action=, result=, or verdict=)
-          agent_outcome=$(echo "$status_line" | grep -oE '(action|result|verdict)=[^ ]+' | cut -d= -f2 | head -1 || echo "")
-          # Parse next field
-          agent_next=$(echo "$status_line" | grep -oE 'next=[^ ]+' | cut -d= -f2 | head -1 || echo "")
-        fi
+        parsed=$("$REPO_ROOT/scripts/parse-status.sh" --from-file "$output_file" "$kind")
+        agent_outcome=$(echo "$parsed" | jq -r '.outcome')
+        agent_next=$(echo "$parsed" | jq -r '.next')
         rm -f "$output_file"
+      else
+        agent_outcome=""
+        agent_next=""
       fi
 
       rm -f "$prompt_file"
@@ -1913,16 +1912,14 @@ else
       rm -f "$LOCK"
       exit "$exit_code"
     }
-    # Parse agent's stdout for successful test run
-    agent_outcome="" agent_next=""
+    # Parse agent's stdout for successful test run using helper
     if [[ -f "$output_file" ]]; then
-      status_line=$(grep -E "^${kind}:" "$output_file" | tail -1 || echo "")
-      if [[ -n "$status_line" ]]; then
-        # Parse outcome field (could be action=, result=, or verdict=)
-        agent_outcome=$(echo "$status_line" | grep -oE '(action|result|verdict)=[^ ]+' | cut -d= -f2 | head -1 || echo "")
-        # Parse next field
-        agent_next=$(echo "$status_line" | grep -oE 'next=[^ ]+' | cut -d= -f2 | head -1 || echo "")
-      fi
+      parsed=$("$REPO_ROOT/scripts/parse-status.sh" --from-file "$output_file" "$kind")
+      agent_outcome=$(echo "$parsed" | jq -r '.outcome')
+      agent_next=$(echo "$parsed" | jq -r '.next')
+    else
+      agent_outcome=""
+      agent_next=""
     fi
     rm -f "$prompt_file" "$output_file"
   else
@@ -1933,16 +1930,15 @@ else
       log "agent exited non-zero (${exit_code}) for #${number}"
 
       # Parse agent's stdout for outcome and next hint
-      agent_outcome="" agent_next=""
+      # Parse agent status line using helper
       if [[ -f "$output_file" ]]; then
-        status_line=$(grep -E "^${kind}:" "$output_file" | tail -1 || echo "")
-        if [[ -n "$status_line" ]]; then
-          # Parse outcome field (could be action=, result=, or verdict=)
-          agent_outcome=$(echo "$status_line" | grep -oE '(action|result|verdict)=[^ ]+' | cut -d= -f2 | head -1 || echo "")
-          # Parse next field
-          agent_next=$(echo "$status_line" | grep -oE 'next=[^ ]+' | cut -d= -f2 | head -1 || echo "")
-        fi
+        parsed=$("$REPO_ROOT/scripts/parse-status.sh" --from-file "$output_file" "$kind")
+        agent_outcome=$(echo "$parsed" | jq -r '.outcome')
+        agent_next=$(echo "$parsed" | jq -r '.next')
         rm -f "$output_file"
+      else
+        agent_outcome=""
+        agent_next=""
       fi
 
       # Capture failure information (issue #751)
@@ -1962,16 +1958,14 @@ else
 fi
 
 # Parse agent's stdout for outcome and next hint
-agent_outcome="" agent_next=""
 if [[ "${GIT_BEE_UI:-}" != "tmux" ]] || ! command -v tmux >/dev/null 2>&1 || ! tmux has-session -t git-bee 2>/dev/null; then
-  # For non-tmux mode, parse from the log file
-  status_line=$(tail -100 "$LOG" | grep -E "^[0-9T:Z-]+ ${kind}:" | tail -1 | cut -d' ' -f2- || echo "")
-  if [[ -n "$status_line" ]]; then
-    # Parse outcome field (could be action=, result=, or verdict=)
-    agent_outcome=$(echo "$status_line" | grep -oE '(action|result|verdict)=[^ ]+' | cut -d= -f2 | head -1 || echo "")
-    # Parse next field
-    agent_next=$(echo "$status_line" | grep -oE 'next=[^ ]+' | cut -d= -f2 | head -1 || echo "")
-  fi
+  # For non-tmux mode, parse from the log file using helper
+  parsed=$("$REPO_ROOT/scripts/parse-status.sh" --from-log "$LOG" "$kind")
+  agent_outcome=$(echo "$parsed" | jq -r '.outcome')
+  agent_next=$(echo "$parsed" | jq -r '.next')
+else
+  agent_outcome=""
+  agent_next=""
 fi
 
 log "agent exited cleanly for #${number}"

--- a/tests/e2e/test-parse-status.sh
+++ b/tests/e2e/test-parse-status.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# E2E test for parse-status.sh extraction (M4/PR 11)
+#
+# Test cases:
+# (a) Run scripts/parse-status.sh on valid agent status line → verify parsed JSON output
+# (b) Run on malformed status line → verify error handling
+# (c) Run unit tests for parser → verify all tests pass
+# (d) Edge case: empty input → verify graceful handling
+# (e) Cold-start: fresh clone can run parser with tests
+
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$HERE/../.." && pwd)
+
+# Import test helpers
+source "$HERE/tick-test-helper.sh" 2>/dev/null || true
+
+PASSED=0
+TOTAL=0
+
+echo "=== E2E Test: parse-status.sh (M4/PR 11) ==="
+echo
+
+# Test case (a): Parse valid agent status line
+test_case() {
+  local name="$1"
+  TOTAL=$((TOTAL + 1))
+  echo -n "Test $TOTAL: $name ... "
+}
+
+pass() {
+  PASSED=$((PASSED + 1))
+  echo "✓"
+}
+
+fail() {
+  echo "✗"
+  echo "  $1"
+}
+
+# (a) Valid status line parsing
+test_case "Parse valid drafter status line"
+result=$("$REPO_ROOT/scripts/parse-status.sh" "drafter: issue=123 action=implemented next=reviewer")
+outcome=$(echo "$result" | jq -r '.outcome')
+next=$(echo "$result" | jq -r '.next')
+if [[ "$outcome" == "implemented" ]] && [[ "$next" == "reviewer" ]]; then
+  pass
+else
+  fail "Expected outcome=implemented, next=reviewer; got outcome=$outcome, next=$next"
+fi
+
+# (b) Malformed status line (graceful degradation)
+test_case "Handle malformed status line"
+result=$("$REPO_ROOT/scripts/parse-status.sh" "garbage input without markers")
+outcome=$(echo "$result" | jq -r '.outcome')
+next=$(echo "$result" | jq -r '.next')
+if [[ "$outcome" == "" ]] && [[ "$next" == "" ]]; then
+  pass
+else
+  fail "Expected empty outcome/next; got outcome=$outcome, next=$next"
+fi
+
+# (c) Unit tests pass
+test_case "Unit tests pass"
+if "$REPO_ROOT/tests/test-parse-status.sh" >/dev/null 2>&1; then
+  pass
+else
+  fail "Unit tests failed"
+fi
+
+# (d) Empty input handling
+test_case "Handle empty input"
+result=$("$REPO_ROOT/scripts/parse-status.sh" "")
+outcome=$(echo "$result" | jq -r '.outcome')
+next=$(echo "$result" | jq -r '.next')
+if [[ "$outcome" == "" ]] && [[ "$next" == "" ]]; then
+  pass
+else
+  fail "Expected empty outcome/next; got outcome=$outcome, next=$next"
+fi
+
+# (e) --from-file mode
+test_case "Parse from file"
+TEMP_FILE=$(mktemp)
+trap "rm -f $TEMP_FILE" EXIT
+cat > "$TEMP_FILE" <<'EOF'
+Some agent output
+reviewer: pr=456 verdict=approved next=e2e
+More output
+EOF
+result=$("$REPO_ROOT/scripts/parse-status.sh" --from-file "$TEMP_FILE" "reviewer")
+outcome=$(echo "$result" | jq -r '.outcome')
+next=$(echo "$result" | jq -r '.next')
+if [[ "$outcome" == "approved" ]] && [[ "$next" == "e2e" ]]; then
+  pass
+else
+  fail "Expected outcome=approved, next=e2e; got outcome=$outcome, next=$next"
+fi
+
+# (f) --from-log mode
+test_case "Parse from timestamped log"
+TEMP_LOG=$(mktemp)
+cat > "$TEMP_LOG" <<'EOF'
+2026-04-28T10:00:00Z drafter: issue=789 action=claimed next=none
+2026-04-28T10:05:00Z drafter: issue=789 action=implemented next=reviewer
+EOF
+result=$("$REPO_ROOT/scripts/parse-status.sh" --from-log "$TEMP_LOG" "drafter")
+outcome=$(echo "$result" | jq -r '.outcome')
+next=$(echo "$result" | jq -r '.next')
+rm -f "$TEMP_LOG"
+if [[ "$outcome" == "implemented" ]] && [[ "$next" == "reviewer" ]]; then
+  pass
+else
+  fail "Expected outcome=implemented, next=reviewer; got outcome=$outcome, next=$next"
+fi
+
+# (g) Integration: tick.sh uses parse-status.sh
+test_case "tick.sh calls parse-status.sh"
+if grep -q "parse-status.sh" "$REPO_ROOT/scripts/tick.sh"; then
+  pass
+else
+  fail "tick.sh doesn't call parse-status.sh"
+fi
+
+# (h) Old parsing pattern removed
+test_case "Old parsing pattern removed from tick.sh"
+if ! grep -q "grep -oE '(action|result|verdict)=" "$REPO_ROOT/scripts/tick.sh"; then
+  pass
+else
+  fail "Old parsing pattern still exists in tick.sh"
+fi
+
+echo
+echo "=== Results ==="
+echo "Passed: $PASSED/$TOTAL"
+
+# Output JSON for compatibility with verify.sh
+printf '{"passed": %d, "total": %d}\n' "$PASSED" "$TOTAL"
+
+if [[ $PASSED -eq $TOTAL ]]; then
+  echo "✓ All E2E tests passed"
+  exit 0
+else
+  echo "✗ Some E2E tests failed"
+  exit 1
+fi

--- a/tests/test-parse-status.sh
+++ b/tests/test-parse-status.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# Test suite for parse-status.sh
+
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+SCRIPT="$HERE/../scripts/parse-status.sh"
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Test counter
+TESTS=0
+PASSED=0
+
+# Test function
+run_test() {
+  local test_name="$1"
+  local expected_result="$2"
+  shift 2
+  local actual_result
+
+  TESTS=$((TESTS + 1))
+
+  # Run the command and capture output
+  if actual_result=$("$@" 2>/dev/null); then
+    # Normalize JSON (remove whitespace differences)
+    actual_result=$(echo "$actual_result" | tr -d ' \n')
+    expected_result=$(echo "$expected_result" | tr -d ' \n')
+
+    if [[ "$actual_result" == "$expected_result" ]]; then
+      echo -e "${GREEN}✓${NC} $test_name"
+      PASSED=$((PASSED + 1))
+    else
+      echo -e "${RED}✗${NC} $test_name"
+      echo "  Expected: $expected_result"
+      echo "  Got: $actual_result"
+    fi
+  else
+    echo -e "${RED}✗${NC} $test_name (command failed)"
+  fi
+}
+
+echo "Testing parse-status.sh..."
+echo
+
+# Test 1: Parse status line with action= and next=
+run_test "Parse action=approved next=e2e" \
+  '{"outcome": "approved", "next": "e2e"}' \
+  "$SCRIPT" "reviewer: issue=123 action=approved next=e2e"
+
+# Test 2: Parse status line with result= and next=
+run_test "Parse result=passed next=merger" \
+  '{"outcome": "passed", "next": "merger"}' \
+  "$SCRIPT" "e2e: pr=456 result=passed next=merger"
+
+# Test 3: Parse status line with verdict= and next=
+run_test "Parse verdict=changes-requested next=drafter" \
+  '{"outcome": "changes-requested", "next": "drafter"}' \
+  "$SCRIPT" "reviewer: pr=789 verdict=changes-requested next=drafter"
+
+# Test 4: Parse status line with only action=, no next=
+run_test "Parse action only (no next)" \
+  '{"outcome": "implemented", "next": ""}' \
+  "$SCRIPT" "drafter: issue=111 action=implemented"
+
+# Test 5: Parse status line with only next=, no outcome
+run_test "Parse next only (no outcome)" \
+  '{"outcome": "", "next": "reviewer"}' \
+  "$SCRIPT" "drafter: issue=222 next=reviewer"
+
+# Test 6: Parse empty status line
+run_test "Parse empty status line" \
+  '{"outcome": "", "next": ""}' \
+  "$SCRIPT" ""
+
+# Test 7: Parse status line with action=implemented-tiny
+run_test "Parse action=implemented-tiny next=merger" \
+  '{"outcome": "implemented-tiny", "next": "merger"}' \
+  "$SCRIPT" "drafter: issue=333 action=implemented-tiny next=merger"
+
+# Test 8: Parse status line with dashes in values
+run_test "Parse action=no-op-waiting" \
+  '{"outcome": "no-op-waiting", "next": "none"}' \
+  "$SCRIPT" "drafter: issue=444 action=no-op-waiting next=none"
+
+# Test 9: --from-file with non-existent file
+run_test "--from-file with missing file" \
+  '{"outcome": "", "next": ""}' \
+  "$SCRIPT" --from-file "/tmp/nonexistent-$$.txt" "drafter"
+
+# Test 10: --from-file with actual file
+TEMP_FILE=$(mktemp)
+cat > "$TEMP_FILE" <<'EOF'
+Some output here
+drafter: issue=555 action=implemented next=reviewer
+More output
+EOF
+run_test "--from-file with valid file" \
+  '{"outcome": "implemented", "next": "reviewer"}' \
+  "$SCRIPT" --from-file "$TEMP_FILE" "drafter"
+rm -f "$TEMP_FILE"
+
+# Test 11: --from-file with multiple status lines (should take last)
+TEMP_FILE=$(mktemp)
+cat > "$TEMP_FILE" <<'EOF'
+drafter: issue=666 action=claimed next=none
+drafter: issue=666 action=implemented next=reviewer
+EOF
+run_test "--from-file takes last status line" \
+  '{"outcome": "implemented", "next": "reviewer"}' \
+  "$SCRIPT" --from-file "$TEMP_FILE" "drafter"
+rm -f "$TEMP_FILE"
+
+# Test 12: --from-log with timestamped entries
+TEMP_LOG=$(mktemp)
+cat > "$TEMP_LOG" <<'EOF'
+2026-04-28T10:00:00Z drafter: issue=777 action=claimed next=none
+2026-04-28T10:05:00Z reviewer: pr=778 verdict=approved next=e2e
+2026-04-28T10:10:00Z drafter: issue=777 action=implemented next=reviewer
+EOF
+run_test "--from-log parses timestamped log" \
+  '{"outcome": "implemented", "next": "reviewer"}' \
+  "$SCRIPT" --from-log "$TEMP_LOG" "drafter"
+rm -f "$TEMP_LOG"
+
+# Test 13: --from-log with non-existent file
+run_test "--from-log with missing file" \
+  '{"outcome": "", "next": ""}' \
+  "$SCRIPT" --from-log "/tmp/nonexistent-log-$$.txt" "e2e"
+
+# Test 14: Check script is executable
+if [[ -x "$SCRIPT" ]]; then
+  echo -e "${GREEN}✓${NC} Script is executable"
+  PASSED=$((PASSED + 1))
+else
+  echo -e "${RED}✗${NC} Script is not executable"
+fi
+TESTS=$((TESTS + 1))
+
+echo
+echo "Results: $PASSED/$TESTS tests passed"
+
+# Output JSON for E2E test compatibility
+printf '{"passed": %d, "total": %d}\n' "$PASSED" "$TESTS"
+
+if [[ $PASSED -eq $TESTS ]]; then
+  echo -e "${GREEN}All tests passed!${NC}"
+  exit 0
+else
+  echo -e "${RED}Some tests failed${NC}"
+  exit 1
+fi


### PR DESCRIPTION
**drafter:**

## Summary

Extracts the duplicated agent status-line parsing logic from tick.sh into a separately-testable helper script. This is required before Phase 2 can port the parsing logic to breeze.

**Problem:** tick.sh currently has 5 duplicated blocks of grep/cut/sed logic that parse agent status lines (`action=X next=Y`). This duplication makes maintenance error-prone and blocks Phase 2 migration to breeze, which needs the parser as a standalone module.

**Solution:** New `scripts/parse-status.sh` helper with three modes:
- Direct parsing: `parse-status.sh "<status-line>"`
- From file: `parse-status.sh --from-file <file> <agent-kind>`
- From log: `parse-status.sh --from-log <log> <agent-kind>`

All modes output JSON: `{"outcome": "...", "next": "..."}`

**Changes:**
- Created `scripts/parse-status.sh` (93 lines)
- Refactored tick.sh to use the helper in all 5 parsing locations
- Removed old grep/cut/sed inline parsing pattern
- Added unit tests: `tests/test-parse-status.sh` (14 test cases, all pass)
- Added E2E tests: `tests/e2e/test-parse-status.sh` (8 test cases, all pass)

**Test coverage:**
- Unit: 14/14 pass
- E2E: 8/8 pass
- All edge cases covered: empty input, missing files, malformed status lines

## Refs

Refs #798 (v0.2.0 roadmap, M4/PR 11)

Part of M4 (minimal breeze alignment). This extraction is required for Phase 2 breeze migration.

## Test plan

Run the test suite:
```bash
# Unit tests
./tests/test-parse-status.sh

# E2E tests
./tests/e2e/test-parse-status.sh

# Verify tick.sh integration
grep -c "parse-status.sh" scripts/tick.sh  # Should be 5
grep "grep -oE '(action|result|verdict)=" scripts/tick.sh  # Should be empty
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>